### PR TITLE
Travis automated building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+node_js:
+  - "stable"
+cache:
+  directories:
+    - node_modules
+before_script:
+  - npm install -g yarn
+install:
+  - yarn
+script:
+  - yarn build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
     - node_modules
 before_script:
   - npm install -g yarn
+  - cp config.example.js config.js
 install:
   - yarn
 script:


### PR DESCRIPTION
Setting up a simple travis config to make sure the application builds.

Travis uses cached node_modules, and circumstantially uses `config.example.js` as `config.js` (which is .gitignored) to allow building.

Still investigating how to merge develop into staging periodically.

closes #15 