### PR TITLE
Topic/sources

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -81,8 +81,21 @@ export function fetchDomain () {
         .catch(handleError('tags'))
     }
 
-    return Promise.all([eventPromise, catPromise, narPromise,
-      sitesPromise, tagsPromise])
+    let sourcesPromise = Promise.resolve([])
+    if (process.env.features.USE_SOURCES) {
+      sourcesPromise = fetch(SOURCES_URL)
+        .then(response => response.json())
+        .catch(handleError('sources'))
+    }
+
+    return Promise.all([
+      eventPromise,
+      catPromise,
+      narPromise,
+      sitesPromise,
+      tagsPromise,
+      sourcesPromise
+    ])
       .then(response => {
         dispatch(toggleFetchingDomain())
         const result = {
@@ -91,6 +104,7 @@ export function fetchDomain () {
           narratives: response[2],
           sites: response[3],
           tags: response[4],
+          sources: response[5],
           notifications
         }
         return result
@@ -114,14 +128,7 @@ export const UPDATE_DOMAIN = 'UPDATE_DOMAIN'
 export function updateDomain(domain) {
   return {
     type: UPDATE_DOMAIN,
-    domain: {
-      events: domain.events,
-      categories: domain.categories,
-      tags: domain.tags,
-      sites: domain.sites,
-      narratives: domain.narratives,
-      notifications: domain.notifications
-    }
+    domain
   }
 }
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -126,18 +126,14 @@ export function updateDomain(domain) {
 }
 
 
-export function fetchSelected(selected) {
-  if (!selected || !selected.length || selected.length === 0) {
-    return updateSelected([])
-  }
+export function fetchSource(source) {
   return dispatch => {
-    dispatch(updateSelected(selected))
     if (!SOURCES_URL) {
       dispatch(fetchSourceError('No source extension specified.'))
     } else {
       dispatch(toggleFetchingSources())
 
-      fetch(SOURCES_URL)
+      fetch(`${SOURCES_URL}`)
         .then(response => {
           if (!response.ok) {
             throw new Error('No sources are available at the URL specified in the config specified.')

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -86,19 +86,17 @@ class Card extends React.Component {
     )
   }
 
-  renderSource() {
-    return (
+  renderSources() {
+    return this.props.event.sources.map(source => (
       <CardSource
         isLoading={this.props.isLoading}
         language={this.props.language}
-        sources={[
-          ...this.props.event.sources.map(s => ({
-            ...s,
-            error: this.props.sourceError
-          })),
-        ]}
+        source={{
+          ...source,
+          error: this.props.sourceError
+        }}
       />
-    )
+    ))
   }
 
   // NB: should be internaionalized.
@@ -147,7 +145,7 @@ class Card extends React.Component {
       return (
         <div className="card-bottomhalf">
           {this.renderTags()}
-          {this.renderSource()}
+          {this.renderSources()}
           {this.renderNarrative()}
         </div>
       )

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -91,10 +91,12 @@ class Card extends React.Component {
       <CardSource
         isLoading={this.props.isLoading}
         language={this.props.language}
-        source={{
-          ...this.props.source,
-          error: this.props.sourceError
-        }}
+        sources={[
+          ...this.props.event.sources.map(s => ({
+            ...s,
+            error: this.props.sourceError
+          })),
+        ]}
       />
     )
   }

--- a/src/components/CardStack.jsx
+++ b/src/components/CardStack.jsx
@@ -89,7 +89,7 @@ class CardStack extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    selected: state.app.selected,
+    selected: selectors.selectSelected(state),
     sourceError: state.app.errors.source,
     language: state.app.language,
     isCardstack: state.app.flags.isCardstack,

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -32,7 +32,7 @@ class Dashboard extends React.Component {
   componentDidMount() {
     if (!this.props.app.isMobile) {
       this.props.actions.fetchDomain()
-        .then((domain) => this.props.actions.updateDomain(domain));
+        .then(domain => this.props.actions.updateDomain(domain));
     }
   }
 

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -51,7 +51,7 @@ class Dashboard extends React.Component {
       let eventsToSelect = selected.map(event => this.getEventById(event.id));
       eventsToSelect = eventsToSelect.sort((a, b) => parseDate(a.timestamp) - parseDate(b.timestamp))
 
-      this.props.actions.fetchSelected(eventsToSelect)
+      this.props.actions.updateSelected(eventsToSelect)
     }
   }
 

--- a/src/components/presentational/CardSource.js
+++ b/src/components/presentational/CardSource.js
@@ -3,23 +3,21 @@ import Spinner from './Spinner'
 
 import copy from '../../js/data/copy.json'
 
-const CardSource = ({ sources, language, isLoading, error }) => {
-  const source_lang = copy[language].cardstack.source
+function renderSource(source) {
+  return source.error ? (
+    <div><small>{source.error}</small></div>
+  ) : (
+    <div><p>TODO: display source properly.</p></div>
+  )
+}
 
-  function renderSource(source) {
-    return source.error ? (
-      <div><small>{source.error}</small></div>
-    ) : (
-      <div><p>TODO: display source properly.</p></div>
-    )
-  }
+const CardSource = ({ source, language, isLoading, error }) => {
+  const source_lang = copy[language].cardstack.source
 
   function renderContent() {
     return isLoading
       ? <Spinner/>
-      : sources.map(
-        source => renderSource(source)
-      )
+      : renderSource(source)
   }
 
   return (

--- a/src/components/presentational/CardSource.js
+++ b/src/components/presentational/CardSource.js
@@ -3,10 +3,10 @@ import Spinner from './Spinner'
 
 import copy from '../../js/data/copy.json'
 
-const CardSource = ({ source, language, isLoading, error }) => {
+const CardSource = ({ sources, language, isLoading, error }) => {
   const source_lang = copy[language].cardstack.source
 
-  function renderSource() {
+  function renderSource(source) {
     return source.error ? (
       <div><small>{source.error}</small></div>
     ) : (
@@ -15,7 +15,11 @@ const CardSource = ({ source, language, isLoading, error }) => {
   }
 
   function renderContent() {
-    return isLoading ? <Spinner/> : renderSource()
+    return isLoading
+      ? <Spinner/>
+      : sources.map(
+        source => renderSource(source)
+      )
   }
 
   return (

--- a/src/components/presentational/CardSource.js
+++ b/src/components/presentational/CardSource.js
@@ -7,7 +7,9 @@ function renderSource(source) {
   return source.error ? (
     <div><small>{source.error}</small></div>
   ) : (
-    <div><p>TODO: display source properly.</p></div>
+    <div>
+      <p>{source.id}</p>
+    </div>
   )
 }
 
@@ -21,7 +23,7 @@ const CardSource = ({ source, language, isLoading, error }) => {
   }
 
   return (
-    <div className="card-col card-cell source">
+    <div className="card-row card-cell source">
       <h4>{source_lang}: </h4>
       {renderContent()}
     </div>

--- a/src/reducers/schema/eventSchema.js
+++ b/src/reducers/schema/eventSchema.js
@@ -12,7 +12,7 @@ const eventSchema = Joi.object().keys({
     type:             Joi.string().allow(''),
     category:         Joi.string().required(),
     narrative:        Joi.string().allow(''),
-    source:           Joi.string().allow(''),
+    sources:          Joi.array(),
     tags:             Joi.string().allow(''),
     comments:         Joi.string().allow(''),
     timestamp:        Joi.string().required(),

--- a/src/reducers/schema/sourceSchema.js
+++ b/src/reducers/schema/sourceSchema.js
@@ -1,0 +1,17 @@
+import Joi from 'joi';
+
+const sourceSchema = Joi.object().keys({
+  id:             Joi.string().required(),
+  path:           Joi.string().required(),
+  type:           Joi.string().allow(''),
+  affil_1:        Joi.string().allow(''),
+  affil_2:        Joi.string().allow(''),
+  url:            Joi.string().allow(''),
+  title:          Joi.string().allow(''),
+  parent:         Joi.string(),
+  author:         Joi.string().allow(''),
+  date:           Joi.string(),
+  notes:          Joi.string().allow('')
+});
+
+export default sourceSchema;

--- a/src/reducers/schema/sourceSchema.js
+++ b/src/reducers/schema/sourceSchema.js
@@ -8,9 +8,9 @@ const sourceSchema = Joi.object().keys({
   affil_2:        Joi.string().allow(''),
   url:            Joi.string().allow(''),
   title:          Joi.string().allow(''),
-  parent:         Joi.string(),
+  parent:         Joi.string().allow(''),
   author:         Joi.string().allow(''),
-  date:           Joi.string(),
+  date:           Joi.string().allow(''),
   notes:          Joi.string().allow('')
 });
 

--- a/src/reducers/utils/validators.js
+++ b/src/reducers/utils/validators.js
@@ -1,9 +1,10 @@
 import Joi from 'joi';
 
-import eventSchema from '../schema/eventSchema.js';
-import categorySchema from '../schema/categorySchema.js';
-import siteSchema from '../schema/siteSchema.js';
-import narrativeSchema from '../schema/narrativeSchema.js';
+import eventSchema from '../schema/eventSchema';
+import categorySchema from '../schema/categorySchema';
+import siteSchema from '../schema/siteSchema';
+import narrativeSchema from '../schema/narrativeSchema';
+import sourceSchema from '../schema/sourceSchema'
 
 import { capitalize } from './helpers.js';
 
@@ -59,6 +60,7 @@ export function validateDomain (domain) {
     categories: [],
     sites: [],
     narratives: [],
+    sources: [],
     notifications: domain.notifications,
     tags: {}
   }
@@ -68,6 +70,7 @@ export function validateDomain (domain) {
     categories: [],
     sites: [],
     narratives: [],
+    sources: [],
   }
 
   function validateItem(item, domainClass, schema) {
@@ -95,6 +98,9 @@ export function validateDomain (domain) {
   domain.narratives.forEach(narrative => {
     validateItem(narrative, 'narratives', narrativeSchema);
   });
+  domain.sources.forEach(source => {
+    validateItem(source, 'sources', sourceSchema);
+  })
 
 
   // Message the number of failed items in domain

--- a/src/scss/cardstack.scss
+++ b/src/scss/cardstack.scss
@@ -1,6 +1,8 @@
 @import 'burger';
 @import 'card';
 
+$card-width: 500px;
+
 .card-stack {
   position: absolute;
   top: 10px;
@@ -20,7 +22,7 @@
   .card-stack-header {
     min-height: 38px;
     line-height: 38px;
-    width: 360px;
+    width: $card-width;
     box-sizing: border-box;
     padding: 0 5px;
     background: $black;
@@ -61,7 +63,7 @@
   }
 
   .card-stack-content {
-    width: 360px;
+    width: $card-width;
 
     ul {
       padding: 0;

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -1,14 +1,17 @@
-import {
-  createSelector
-} from 'reselect'
+import { createSelector} from 'reselect'
 
 // Input selectors
 export const getEvents = state => state.domain.events;
 export const getLocations = state => state.domain.locations;
 export const getCategories = state => state.domain.categories;
 export const getNarratives = state => state.domain.narratives;
+export const getSelected = state => state.app.selected;
 export const getSites = (state) => {
   if (process.env.features.USE_SITES) return state.domain.sites;
+  return [];
+}
+export const getSources = state => {
+  if (process.env.features.USE_SOURCES) return state.domain.sources;
   return [];
 }
 export const getNotifications = state => state.domain.notifications;
@@ -152,6 +155,23 @@ export const selectLocations = createSelector(
   }
 );
 
+/**
+ * Of all the sources, select those that are relevant to the selected events.
+ */
+export const selectSelected = createSelector(
+  [getSelected, getSources],
+  (selected, sources) => {
+    if (selected.length === 0) {
+      return []
+    }
+    const sourceIds = selected.map(e => e.source)
+    const srcs = sources.filter(s => s.id.indexOf(sourceIds) > -1)
+    return selected.map((s, idx) => ({
+      ...s,
+      source: srcs[idx]
+    }))
+  }
+)
 
 /*
 * Select categories, return them as a list

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -165,12 +165,14 @@ export const selectSelected = createSelector(
       return []
     }
     const srcs = selected
-      .map(e => e.source)
-      .map(id => sources[id])
+      .map(e => e.sources)
+      .map(_sources =>
+        _sources.map(id => sources[id])
+      )
 
     return selected.map((s, idx) => ({
       ...s,
-      source: srcs[idx]
+      sources: srcs[idx]
     }))
   }
 )

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -164,8 +164,10 @@ export const selectSelected = createSelector(
     if (selected.length === 0) {
       return []
     }
-    const sourceIds = selected.map(e => e.source)
-    const srcs = sources.filter(s => s.id.indexOf(sourceIds) > -1)
+    const srcs = selected
+      .map(e => e.source)
+      .map(id => sources[id])
+
     return selected.map((s, idx) => ({
       ...s,
       source: srcs[idx]

--- a/src/store/initial.js
+++ b/src/store/initial.js
@@ -106,7 +106,7 @@ const initial = {
   ui: {
     style: {
       categories: {
-        default: 'red',
+        default: 'yellow',
         // Add here other categories to differentiate by color, like:
         alpha: '#00ff00',
         beta: '#ff0000',
@@ -115,17 +115,11 @@ const initial = {
 
       narratives: {
         default: {
-          style: 'dotted',                  // ['dotted', 'solid']
-          opacity: 0.9,                     // range between 0 and 1
-          stroke: 'red',               // Any hex or rgb code
+          style: 'solid',                  // ['dotted', 'solid']
+          opacity: 0.5,                     // range between 0 and 1
+          stroke: 'transparent',               // Any hex or rgb code
           strokeWidth: 2
         },
-        narrative_1: {
-          style: 'solid',                  // ['dotted', 'solid']
-          opacity: 0.4,                     // range between 0 and 1
-          stroke: '#f18f01',               // Any hex or rgb code
-          strokeWidth: 2
-        }
       }
     },
     dom: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,7 +64,8 @@ const config = {
         'features': {
           'USE_TAGS': JSON.stringify(userConfig.features.USE_TAGS),
           'USE_SEARCH': JSON.stringify(userConfig.features.USE_SEARCH),
-          'USE_SITES': JSON.stringify(userConfig.features.USE_SITES)
+          'USE_SITES': JSON.stringify(userConfig.features.USE_SITES),
+          'USE_SOURCES': JSON.stringify(userConfig.features.USE_SOURCES)
         }
       }
     }),


### PR DESCRIPTION
Towards closing #20 -- but another PR will be required as well to support asynchronous loading of the associated URLs.

This PR adds infrastructure to load sources into the redux state when the app originally fetches its domain, and then present those sources in `Card.jsx` (currently in a very rudimentary way) when the card is toggled open.

Note that due to the fact that we are allowing multiple sources per event, this needs to be tested in tandem with [this PR in datasheet server](https://github.com/forensic-architecture/datasheet-server/pull/29), which presents 'deeprows' from a sheet as a list of values. The config should be changed to look something like:
```js
{
    // other fields
    EVENTS_EXT: '/api/example/export_events/deeprows',
    SOURCES_EXT: '/api/example/export_sources/ids'
}
```

The appropriate blueprinters should be added in your datasheet server instance as well, so that the appropriate structured data is available there: `BP.deeprows` for the 'export_events' tab, and `BP.ids` for the 'export_sources' tab.

This PR does not include asynchronous loading of URLs in the sources metadata that are loaded upfront, but it prepares for this in a coming PR, by channeling all of the relevant source data and making it available in the `Card` and `CardSource` components using [a selector](https://github.com/forensic-architecture/timemap/blob/461f7375c3a703d910d4432464bd23f6b99d0334/src/selectors/index.js#L161-L178).

The 