### PR TITLE
Implement focused narrative mode

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -97,7 +97,6 @@ export function fetchDomain () {
       sourcesPromise
     ])
       .then(response => {
-        dispatch(toggleFetchingDomain())
         const result = {
           events: response[0],
           categories: response[1],
@@ -107,11 +106,16 @@ export function fetchDomain () {
           sources: response[5],
           notifications
         }
+        if (Object.values(result).some(resp => resp.hasOwnProperty('error'))) {
+          throw new Error('Some URLs returned negative. If you are in development, check the server is running')
+        }
         return result
       })
       .catch(err => {
         dispatch(fetchError(err.message))
         dispatch(toggleFetchingDomain())
+        // TODO: handle this appropriately in React hierarchy
+        alert(err.message)
       })
   };
 }

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -129,11 +129,11 @@ class Card extends React.Component {
   renderHeader() {
     return (
       <div className="card-collapsed">
-        <div className="card-column">
+        <div className="card-row">
           {this.renderTimestamp()}
           {this.renderLocation()}
         </div>
-        {/* {this.renderCategory()} */}
+        {this.renderCategory()}
         <br/>
         {this.renderSummary()}
       </div>

--- a/src/components/CardStack.jsx
+++ b/src/components/CardStack.jsx
@@ -36,17 +36,6 @@ class CardStack extends React.Component {
     return '';
   }
 
-  renderLocation() {
-    let locationName = copy[this.props.language].cardstack.unknown_location;
-    if (this.props.selected.length > 0) {
-      if (isNotNullNorUndefined(this.props.selected[0].location)) {
-        locationName = this.props.selected[0].location;
-      }
-      return (<p className="header-copy">in:<b>{` ${locationName}`}</b></p>)
-    }
-    return '';
-  }
-
   renderCardStackHeader() {
     const header_lang = copy[this.props.language].cardstack.header;
 

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -94,10 +94,13 @@ class Dashboard extends React.Component {
             getCategoryColor: category => this.getCategoryColor(category)
           }}
         />
-        <NarrativeCard
-          onSelect={this.handleSelect}
-          onSelectNarrative={(narrative) => { this.props.actions.updateNarrative(narrative); }}
-        />
+        {(this.props.app.narrative !== null)
+            ? <NarrativeCard
+              onSelect={this.handleSelect}
+              onSelectNarrative={(narrative) => { this.props.actions.updateNarrative(narrative); }}
+            />
+            : ''
+        }
         <CardStack
           onSelect={this.handleSelect}
           onHighlight={this.handleHighlight}

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -76,22 +76,16 @@ class Dashboard extends React.Component {
   render() {
     return (
       <div>
+        <Toolbar
+          onFilter={this.handleTagFilter}
+          onSelectNarrative={(narrative) => { this.props.actions.updateNarrative(narrative); }}
+          actions={this.props.actions}
+        />
         <Viewport
           methods={{
             onSelect: this.handleSelect,
             getCategoryColor: category => this.getCategoryColor(category)
           }}
-        />
-        <Toolbar
-          onFilter={this.handleTagFilter}
-          actions={this.props.actions}
-        />
-        <CardStack
-          onSelect={this.handleSelect}
-          onHighlight={this.handleHighlight}
-          onToggleCardstack={() => this.props.actions.updateSelected([])}
-          getNarrativeLinks={event => this.getNarrativeLinks(event)}
-          getCategoryColor={category => this.getCategoryColor(category)}
         />
         <Timeline
           methods={{
@@ -100,14 +94,21 @@ class Dashboard extends React.Component {
             getCategoryColor: category => this.getCategoryColor(category)
           }}
         />
+        <NarrativeCard
+          onSelect={this.handleSelect}
+          onSelectNarrative={(narrative) => { this.props.actions.updateNarrative(narrative); }}
+        />
+        <CardStack
+          onSelect={this.handleSelect}
+          onHighlight={this.handleHighlight}
+          onToggleCardstack={() => this.props.actions.updateSelected([])}
+          getNarrativeLinks={event => this.getNarrativeLinks(event)}
+          getCategoryColor={category => this.getCategoryColor(category)}
+        />
         <InfoPopUp
           ui={this.props.ui}
           app={this.props.app}
           toggle={() => this.props.actions.toggleInfoPopup()}
-        />
-        <NarrativeCard
-          onSelect={this.handleSelect}
-          actions={this.props.actions}
         />
         <Notification
           isNotification={this.props.app.flags.isNotification}

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -22,7 +22,7 @@ class Dashboard extends React.Component {
 
     this.handleHighlight = this.handleHighlight.bind(this);
     this.handleSelect = this.handleSelect.bind(this);
-    // this.handleToggle = this.handleToggle.bind(this);
+    this.handleSelectNarrative = this.handleSelectNarrative.bind(this);
     this.handleTagFilter = this.handleTagFilter.bind(this);
     this.updateTimerange = this.updateTimerange.bind(this);
 
@@ -55,6 +55,10 @@ class Dashboard extends React.Component {
     }
   }
 
+  handleSelectNarrative(narrative) {
+    this.props.actions.updateNarrative(narrative);
+  }
+
   handleTagFilter(tag) {
     this.props.actions.updateTagFilters(tag);
   }
@@ -78,12 +82,13 @@ class Dashboard extends React.Component {
       <div>
         <Toolbar
           onFilter={this.handleTagFilter}
-          onSelectNarrative={(narrative) => { this.props.actions.updateNarrative(narrative); }}
+          onSelectNarrative={this.handleSelectNarrative}
           actions={this.props.actions}
         />
         <Viewport
           methods={{
             onSelect: this.handleSelect,
+            onSelectNarrative: this.handleSelectNarrative,
             getCategoryColor: category => this.getCategoryColor(category)
           }}
         />
@@ -97,7 +102,7 @@ class Dashboard extends React.Component {
         {(this.props.app.narrative !== null)
             ? <NarrativeCard
               onSelect={this.handleSelect}
-              onSelectNarrative={(narrative) => { this.props.actions.updateNarrative(narrative); }}
+              onSelectNarrative={this.handleSelectNarrative}
             />
             : ''
         }

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -109,9 +109,6 @@ class Dashboard extends React.Component {
           onSelect={this.handleSelect}
           actions={this.props.actions}
         />
-        <NarrativeCard
-          onSelect={this.handleSelect}
-        />
         <Notification
           isNotification={this.props.app.flags.isNotification}
           notifications={this.props.domain.notifications}

--- a/src/components/NarrativeCard.js
+++ b/src/components/NarrativeCard.js
@@ -23,8 +23,13 @@ class NarrativeCard extends React.Component {
     }
   }
 
-  componentDidUpdate() {
-    if (this.props.narrative !== null) {
+  componentDidMount() {
+    const step = this.props.narrative.steps[this.state.step];
+    this.props.onSelect([step]);
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (prevProps.narrative === this.props.narrative && this.state.step !== prevState.step) {
       const step = this.props.narrative.steps[this.state.step];
       this.props.onSelect([step]);
     }
@@ -42,7 +47,7 @@ class NarrativeCard extends React.Component {
   }
 
   render() {
-    if (this.props.narrative !== null && this.props.narrative.steps[this.state.step]) {
+    if (this.props.narrative.steps[this.state.step]) {
       const steps = this.props.narrative.steps;
       const step = steps[this.state.step];
 

--- a/src/components/NarrativeCard.js
+++ b/src/components/NarrativeCard.js
@@ -26,7 +26,6 @@ class NarrativeCard extends React.Component {
   componentDidUpdate() {
     if (this.props.narrative !== null) {
       const step = this.props.narrative.steps[this.state.step];
-      console.log(step)
       this.props.onSelect([step]);
     }
   }

--- a/src/components/NarrativeCard.js
+++ b/src/components/NarrativeCard.js
@@ -49,9 +49,12 @@ class NarrativeCard extends React.Component {
       return (
         <div className="narrative-info">
           {this.renderClose()}
-          <h6>{this.props.narrative.label}</h6>
+          <h3>{this.props.narrative.label}</h3>
           <p>{this.props.narrative.description}</p>
-          <h3>{this.state.step + 1}/{steps.length}. {step.location}</h3>
+          <h6>
+            <i className="material-icons left">location_on</i>
+            {this.state.step + 1}/{steps.length}. {step.location}
+          </h6>
           <div className="actions">
             <div className={`${(!this.state.step) ? 'disabled ' : ''} action`} onClick={() => this.goToPrevKeyFrame()}>&larr;</div>
             <div className={`${(this.state.step >= this.props.narrative.steps.length - 1) ? 'disabled ' : ''} action`} onClick={() => this.goToNextKeyFrame()}>&rarr;</div>

--- a/src/components/NarrativeCard.js
+++ b/src/components/NarrativeCard.js
@@ -32,6 +32,13 @@ class NarrativeCard extends React.Component {
     if (prevProps.narrative === this.props.narrative && this.state.step !== prevState.step) {
       const step = this.props.narrative.steps[this.state.step];
       this.props.onSelect([step]);
+    } else if (prevProps.narrative !== this.props.narrative && this.props.narrative !== null) {
+      this.setState({
+        step: 0
+      }, () => {
+        const step = this.props.narrative.steps[this.state.step];
+        this.props.onSelect([step]);
+      });
     }
   }
 

--- a/src/components/NarrativeCard.js
+++ b/src/components/NarrativeCard.js
@@ -26,6 +26,7 @@ class NarrativeCard extends React.Component {
   componentDidUpdate() {
     if (this.props.narrative !== null) {
       const step = this.props.narrative.steps[this.state.step];
+      console.log(step)
       this.props.onSelect([step]);
     }
   }
@@ -34,7 +35,7 @@ class NarrativeCard extends React.Component {
     return (
       <button
         className="side-menu-burg is-active"
-        onClick={() => { this.props.actions.updateNarrative(null); }}
+        onClick={() => { this.props.onSelectNarrative(null); }}
       >
         <span></span>
       </button>

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -47,6 +47,7 @@ class Timeline extends React.Component {
     const labels_title_lang = copy[this.props.app.language].timeline.labels_title;
     const info_lang = copy[this.props.app.language].timeline.info;
     let classes = `timeline-wrapper ${(this.state.isFolded) ? ' folded' : ''}`;
+    classes += this.props.app.narrative ? 'narrative-mode' : '';
     const date0 = formatterWithYear(this.props.app.timerange[0]);
     const date1 = formatterWithYear(this.props.app.timerange[1]);
 
@@ -80,7 +81,8 @@ function mapStateToProps(state) {
       timerange: selectors.getTimeRange(state),
       selected: state.app.selected,
       language: state.app.language,
-      zoomLevels: state.app.zoomLevels
+      zoomLevels: state.app.zoomLevels,
+      narrative: state.app.narrative
     },
     dom: state.ui.dom,
   }

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import * as selectors from '../selectors';
+import hash from 'object-hash';
 
 import copy from '../js/data/copy.json';
-import { formatterWithYear } from '../js/utilities';
+import { formatterWithYear, isNotNullNorUndefined } from '../js/utilities';
 import TimelineHeader from './presentational/TimelineHeader';
 import TimelineLogic from '../js/timeline/timeline.js';
 
@@ -21,7 +22,9 @@ class Timeline extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    this.timeline.update(nextProps.domain, nextProps.app);
+    if (hash(nextProps) !== hash(this.props)) {
+      this.timeline.update(nextProps.domain, nextProps.app);
+    }
   }
 
   onClickArrow() {
@@ -32,7 +35,7 @@ class Timeline extends React.Component {
 
   render() {
     let classes = `timeline-wrapper ${(this.state.isFolded) ? ' folded' : ''}`;
-
+    classes += (this.props.app.narrative !== null) ? ' narrative-mode' : '';
     return (
       <div className={classes}>
         <TimelineHeader
@@ -60,7 +63,8 @@ function mapStateToProps(state) {
       timerange: selectors.getTimeRange(state),
       selected: state.app.selected,
       language: state.app.language,
-      zoomLevels: state.app.zoomLevels
+      zoomLevels: state.app.zoomLevels,
+      narrative: state.app.narrative
     },
     ui: {
       dom: state.ui.dom,

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -4,6 +4,7 @@ import * as selectors from '../selectors';
 
 import copy from '../js/data/copy.json';
 import { formatterWithYear } from '../js/utilities';
+import TimelineHeader from './presentational/TimelineHeader';
 import TimelineLogic from '../js/timeline/timeline.js';
 
 class Timeline extends React.Component {
@@ -15,18 +16,12 @@ class Timeline extends React.Component {
   }
 
   componentDidMount() {
-    const ui = {
-      dom: this.props.dom
-    }
-
-    this.timeline = new TimelineLogic(this.props.app, ui, this.props.methods);
+    this.timeline = new TimelineLogic(this.props.app, this.props.ui, this.props.methods);
     this.timeline.update(this.props.domain, this.props.app);
-    this.timeline.render(this.props.domain);
   }
 
   componentWillReceiveProps(nextProps) {
     this.timeline.update(nextProps.domain, nextProps.app);
-    this.timeline.render(nextProps.domain);
   }
 
   onClickArrow() {
@@ -35,35 +30,19 @@ class Timeline extends React.Component {
     });
   }
 
-  renderLabels() {
-    const labels = copy[this.props.language].timeline.labels;
-    return this.props.categories.map((label) => {
-      const groupLen = this.props.categories.length
-      return (<div className="timeline-label">{label}</div>);
-    });
-  }
-
   render() {
-    const labels_title_lang = copy[this.props.app.language].timeline.labels_title;
-    const info_lang = copy[this.props.app.language].timeline.info;
     let classes = `timeline-wrapper ${(this.state.isFolded) ? ' folded' : ''}`;
-    classes += this.props.app.narrative ? 'narrative-mode' : '';
-    const date0 = formatterWithYear(this.props.app.timerange[0]);
-    const date1 = formatterWithYear(this.props.app.timerange[1]);
 
     return (
       <div className={classes}>
-        <div className="timeline-header">
-          <div className="timeline-toggle" onClick={() => this.onClickArrow()}>
-            <p><i className="arrow-down"></i></p>
-          </div>
-          <div className="timeline-info">
-            <p>{info_lang}</p>
-            <p>{date0} - {date1}</p>
-          </div>
-        </div>
+        <TimelineHeader
+          title={copy[this.props.app.language].timeline.info}
+          date0={formatterWithYear(this.props.app.timerange[0])}
+          date1={formatterWithYear(this.props.app.timerange[1])}
+          onClick={() => { this.onClickArrow(); }}
+        />
         <div className="timeline-content">
-          <div id="timeline" className="timeline" />
+          <div id={this.props.ui.dom.timeline} className="timeline" />
         </div>
       </div>
     );
@@ -81,10 +60,11 @@ function mapStateToProps(state) {
       timerange: selectors.getTimeRange(state),
       selected: state.app.selected,
       language: state.app.language,
-      zoomLevels: state.app.zoomLevels,
-      narrative: state.app.narrative
+      zoomLevels: state.app.zoomLevels
     },
-    dom: state.ui.dom,
+    ui: {
+      dom: state.ui.dom,
+    }
   }
 }
 

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -175,7 +175,7 @@ class Toolbar extends React.Component {
 
   render() {
     return (
-      <div id="toolbar-wrapper" className="toolbar-wrapper">
+      <div id="toolbar-wrapper" className={`toolbar-wrapper ${this.props.narrative ? 'narrative-mode' : ''}`}>
         {this.renderToolbarTabs()}
         {this.renderToolbarPanels()}
       </div>
@@ -193,6 +193,7 @@ function mapStateToProps(state) {
     categoryFilter: state.app.filters.categories,
     viewFilters: state.app.filters.views,
     features: state.app.features,
+    narrative: state.app.narrative,
   }
 }
 

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -59,8 +59,8 @@ class Toolbar extends React.Component {
   renderToolbarNarrativePanel() {
     return (
       <TabPanel>
-        <h2>Focus stories</h2>
-        <p>Here are some highlighted stories</p>
+        <h2>{copy[this.props.language].toolbar.narrative_panel_title}</h2>
+        <p>{copy[this.props.language].toolbar.narrative_summary}</p>
         {this.props.narratives.map((narr) => {
           return (
             <div className="panel-action action">

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -7,7 +7,7 @@ import Search from './Search.jsx';
 import TagListPanel from './TagListPanel.jsx';
 import ToolbarBottomActions from './ToolbarBottomActions.jsx';
 import copy from '../js/data/copy.json';
-import { isNotNullNorUndefined } from '../js/utilities.js';
+import { isNotNullNorUndefined, trimAndEllipse } from '../js/utilities.js';
 
 class Toolbar extends React.Component {
 
@@ -66,7 +66,7 @@ class Toolbar extends React.Component {
             <div className="panel-action action">
               <button style={{ backgroundColor: '#000' }} onClick={() => { this.goToNarrative(narr); }}>
                 <p>{narr.label}</p>
-                <p><small>{narr.description}</small></p>
+                <p><small>{trimAndEllipse(narr.description, 120)}</small></p>
               </button>
             </div>
           )
@@ -100,6 +100,7 @@ class Toolbar extends React.Component {
 
     return (
       <div className={classes} onClick={() => { this.toggleTab(tabNum); }}>
+        <i className="material-icons">timeline</i>
         <div className="tab-caption">{label}</div>
       </div>
     );

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -7,6 +7,7 @@ import Search from './Search.jsx';
 import TagListPanel from './TagListPanel.jsx';
 import ToolbarBottomActions from './ToolbarBottomActions.jsx';
 import copy from '../js/data/copy.json';
+import { isNotNullNorUndefined } from '../js/utilities.js';
 
 class Toolbar extends React.Component {
 
@@ -174,8 +175,9 @@ class Toolbar extends React.Component {
   }
 
   render() {
+    const isNarrative = isNotNullNorUndefined(this.props.narrative);
     return (
-      <div id="toolbar-wrapper" className={`toolbar-wrapper ${this.props.narrative ? 'narrative-mode' : ''}`}>
+      <div id="toolbar-wrapper" className={`toolbar-wrapper ${(isNarrative) ? 'narrative-mode' : ''}`}>
         {this.renderToolbarTabs()}
         {this.renderToolbarPanels()}
       </div>

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -51,7 +51,7 @@ class Toolbar extends React.Component {
     this.setState({
       tabNum: -1
     }, () => {
-      this.props.actions.updateNarrative(narrative);
+      this.props.onSelectNarrative(narrative);
     });
   }
 

--- a/src/components/Viewport.jsx
+++ b/src/components/Viewport.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import * as selectors from '../selectors'
+import hash from 'object-hash';
+
 import Map from '../js/map/map.js'
 import { areEqual } from '../js/utilities.js'
 
@@ -15,7 +17,9 @@ class Viewport extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    this.map.update(nextProps.domain, nextProps.app)
+    if (hash(nextProps) !== hash(this.props)) {
+      this.map.update(nextProps.domain, nextProps.app)
+    }
   }
 
   render() {

--- a/src/components/Viewport.jsx
+++ b/src/components/Viewport.jsx
@@ -19,8 +19,9 @@ class Viewport extends React.Component {
   }
 
   render() {
+    const classes = this.props.app.narrative ? 'map-wrapper narrative-mode' : 'map-wrapper';
     return (
-      <div className='map-wrapper'>
+      <div className={classes}>
         <div id="map" />
       </div>
     )
@@ -39,7 +40,8 @@ function mapStateToProps(state) {
       views: state.app.filters.views,
       selected: state.app.selected,
       highlighted: state.app.highlighted,
-      mapAnchor: state.app.mapAnchor
+      mapAnchor: state.app.mapAnchor,
+      narrative: state.app.narrative
     },
     ui: {
       dom: state.ui.dom,

--- a/src/components/presentational/TimelineHeader.js
+++ b/src/components/presentational/TimelineHeader.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const TimelineHeader = ({ title, date0, date1, onClick }) => (
+  <div className="timeline-header">
+    <div className="timeline-toggle" onClick={() => onClick()}>
+      <p><i className="arrow-down"></i></p>
+    </div>
+    <div className="timeline-info">
+      <p>{title}</p>
+      <p>{date0} - {date1}</p>
+    </div>
+  </div>
+);
+
+export default TimelineHeader;

--- a/src/js/data/copy.json
+++ b/src/js/data/copy.json
@@ -103,7 +103,9 @@
           "title": "Directory of tags",
           "placeholder": "Search"
         }
-      }
+      },
+      "narrative_panel_title": "Focus narratives",
+      "narrative_summary": "Here you can follow some curated stories we have found in the data."
     },
     "timeline": {
       "zooms": [

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -395,7 +395,7 @@ Stop and start the development process in terminal after you have added your tok
       })
       .style('stroke-opacity', d => {
         if (app.narrative === null) return 0;
-        if (!d[0] || app.narrative.id !== d[0].narrative) return 0.2;
+        if (!d[0] || !d[0].narratives.find(n => n === app.narrative.id)) return 0.2;
         return 1;
       })
       .style('fill', 'none');
@@ -408,7 +408,7 @@ Stop and start the development process in terminal after you have added your tok
       })
       .style('stroke-opacity', d => {
         if (app.narrative === null) return 0;
-        if (!d[0] || app.narrative.id !== d[0].narrative) return 0.2;
+        if (!d[0] || !d[0].narratives.find(n => n === app.narrative.id)) return 0.2;
         return 1;
       })
   }

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -451,7 +451,7 @@ Stop and start the development process in terminal after you have added your tok
   */
   function renderDomain () {
     renderSites();
-    renderNarratives();    
+    renderNarratives();
     renderEvents();
   }
   function renderSelectedAndHighlight () {

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -98,10 +98,24 @@ Stop and start the development process in terminal after you have added your tok
       .attr('viewBox', '0 0 6 6')
       .attr('refX', 3)
       .attr('refY', 3)
-      .attr('markerWidth', 14)
-      .attr('markerHeight', 14)
+      .attr('markerWidth', 6)
+      .attr('markerHeight', 6)
       .attr('orient', 'auto')
       .append('path')
+      .style('fill', 'red')
+      .attr('d', 'M0,3v-3l6,3l-6,3z');
+
+    svg.insert('defs', 'g')
+      .append('marker-off')
+      .attr('id', 'arrow-off')
+      .attr('viewBox', '0 0 6 6')
+      .attr('refX', 3)
+      .attr('refY', 3)
+      .attr('markerWidth', 6)
+      .attr('markerHeight', 6)
+      .attr('orient', 'auto')
+      .append('path')
+      .style('fill', 'black')
       .attr('d', 'M0,3v-3l6,3l-6,3z');
 
     map.on('zoomstart', () => {
@@ -366,6 +380,12 @@ Stop and start the development process in terminal after you have added your tok
       .exit()
       .remove();
 
+    const getMarker = (d) => {
+      if (!d || app.narrative === null) return 'none';
+      if (d.id !== app.narrative.id) return 'url(#arrow-off)';
+      return 'url(#arrow)';
+    }
+
     narrativesDom
       .enter().append('path')
       .attr('class', 'narrative')
@@ -393,12 +413,18 @@ Stop and start the development process in terminal after you have added your tok
       })
       .style('fill', 'none')
       .style('cursor', 'pointer')
+      .attr('marker-start', d => getMarker(d))
+      .attr('marker-end', d => getMarker(d))
+      .attr('mid-marker', d => getMarker(d))
       .on('click', d => {
         console.log(d)
       });
 
     narrativesDom
       .attr('d', d => sequenceLine(d.steps))
+      .attr('marker-start', d => getMarker(d))
+      .attr('marker-end', d => getMarker(d))
+      .attr('mid-marker', d => getMarker(d))
       .style('stroke', d => {
         if (!d || app.narrative === null) return 'none';
         if (d.id !== app.narrative.id) return '#232323';

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -126,6 +126,16 @@ Stop and start the development process in terminal after you have added your tok
   }
 
   function getSVGBoundaries() {
+    const mapNode = d3.select('.leaflet-map-pane').node();
+
+    // We'll get the transform of the leaflet container,
+    // which will let us offset the SVG by the same quantity
+    const transform = window
+      .getComputedStyle(mapNode)
+      .getPropertyValue('transform');
+
+    // However getComputedStyle returns an awkward string of the format
+    // matrix(0, 0, 1, 0, 0.56523, 123123), hence this awkwardness
     return {
       transformX: +transform.split(',')[4],
       transformY: +transform.split(',')[5].split(')')[0]
@@ -138,7 +148,8 @@ Stop and start the development process in terminal after you have added your tok
     let WIDTH = boundingClient.width;
     let HEIGHT = boundingClient.height;
 
-    g.attr('transform', `translate(${-(topLeft.x - 100)},${-(topLeft.y - 100)})`);
+    // Offset with leaflet map transform boundaries
+    const { transformX, transformY } = getSVGBoundaries();
 
     svg.attr('width', WIDTH)
       .attr('height', HEIGHT)
@@ -146,19 +157,18 @@ Stop and start the development process in terminal after you have added your tok
 
     g.selectAll('.location').attr('transform', (d) => {
       const newPoint = projectPoint([+d.latitude, +d.longitude]);
-      return `translate(${newPoint.x},${newPoint.y})`;
+      return `translate(${newPoint.x + transformX},${newPoint.y + transformY})`;
     });
+
+    const sequenceLine = d3.line()
+      .x(d => getCoords(d).x + transformX)
+      .y(d => getCoords(d).y + transformY);
 
     g.selectAll('.narrative')
       .attr('d', sequenceLine);
-
-    const busLine = d3.line()
-      .x(d => lMap.latLngToLayerPoint(d).x)
-      .y(d => lMap.latLngToLayerPoint(d).y)
-      .curve(d3.curveMonotoneX);
   }
 
-  lMap.on("zoom viewreset move", updateSVG);
+  lMap.on("zoomend viewreset moveend", updateSVG);
 
   /**
    * Returns latitud / longitude

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -125,16 +125,6 @@ Stop and start the development process in terminal after you have added your tok
   }
 
   function getSVGBoundaries() {
-    const mapNode = d3.select('.leaflet-map-pane').node();
-
-    // We'll get the transform of the leaflet container,
-    // which will let us offset the SVG by the same quantity
-    const transform = window
-      .getComputedStyle(mapNode)
-      .getPropertyValue('transform');
-
-    // However getComputedStyle returns an awkward string of the format
-    // matrix(0, 0, 1, 0, 0.56523, 123123), hence this awkwardness
     return {
       transformX: +transform.split(',')[4],
       transformY: +transform.split(',')[5].split(')')[0]
@@ -147,8 +137,7 @@ Stop and start the development process in terminal after you have added your tok
     let WIDTH = boundingClient.width;
     let HEIGHT = boundingClient.height;
 
-    // Offset with leaflet map transform boundaries
-    const { transformX, transformY } = getSVGBoundaries();
+    g.attr('transform', `translate(${-(topLeft.x - 100)},${-(topLeft.y - 100)})`);
 
     svg.attr('width', WIDTH)
       .attr('height', HEIGHT)
@@ -161,9 +150,14 @@ Stop and start the development process in terminal after you have added your tok
 
     g.selectAll('.narrative')
       .attr('d', sequenceLine);
+
+    const busLine = d3.line()
+      .x(d => lMap.latLngToLayerPoint(d).x)
+      .y(d => lMap.latLngToLayerPoint(d).y)
+      .curve(d3.curveMonotoneX);
   }
 
-  lMap.on("zoomend viewreset moveend", updateSVG);
+  lMap.on("zoom viewreset move", updateSVG);
 
   /**
    * Returns latitud / longitude

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -451,8 +451,8 @@ Stop and start the development process in terminal after you have added your tok
   */
   function renderDomain () {
     renderSites();
+    renderNarratives();    
     renderEvents();
-    renderNarratives();
   }
   function renderSelectedAndHighlight () {
     renderSelected();

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -160,11 +160,7 @@ Stop and start the development process in terminal after you have added your tok
       return `translate(${newPoint.x},${newPoint.y})`;
     });
 
-    const sequenceLine = d3.line()
-      .x(d => getCoords(d).x + transformX)
-      .y(d => getCoords(d).y + transformY);
-
-    g.selectAll('.narrative')
+    svg.selectAll('.narrative')
       .attr('d', d => sequenceLine(d.steps));
   }
 
@@ -237,9 +233,7 @@ Stop and start the development process in terminal after you have added your tok
   function getLocationEventsDistribution(location) {
     const eventCount = {};
     const categories = domain.categories;
-    // categories.sort((a, b) => {
-    //   return (+a.slice(-2) > +b.slice(-2));
-    // });
+
     categories.forEach(cat => {
       eventCount[cat.category] = 0
     });

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -165,7 +165,7 @@ Stop and start the development process in terminal after you have added your tok
       .y(d => getCoords(d).y + transformY);
 
     g.selectAll('.narrative')
-      .attr('d', sequenceLine);
+      .attr('d', d => sequenceLine(d.steps));
   }
 
   lMap.on("zoomend viewreset moveend", updateSVG);
@@ -365,8 +365,8 @@ Stop and start the development process in terminal after you have added your tok
   }
 
   function renderNarratives() {
-    const narrativesDom = g.selectAll('.narrative')
-      .data(domain.narratives.map(d => d.steps))
+    const narrativesDom = svg.selectAll('.narrative')
+      .data(domain.narratives)
 
     narrativesDom
       .exit()
@@ -375,40 +375,45 @@ Stop and start the development process in terminal after you have added your tok
     narrativesDom
       .enter().append('path')
       .attr('class', 'narrative')
-      .attr('d', sequenceLine)
+      .attr('d', d => sequenceLine(d.steps))
       .style('stroke-width', d => {
-        if (!d[0]) return 0;
-        // Note: [0] is a non-elegant way to get the narrative id out of the first
-        // event in the narrative sequence
-        const styleProps = getNarrativeStyle(d[0].narrative);
+        if (!d) return 0;
+        const styleProps = getNarrativeStyle(d.id);
         return styleProps.strokeWidth;
       })
       .style('stroke-dasharray', d => {
-        if (!d[0]) return 'none';
-        const styleProps = getNarrativeStyle(d[0].narrative);
+        if (!d) return 'none';
+        const styleProps = getNarrativeStyle(d.id);
         return (styleProps.style === 'dotted') ? "2px 5px" : 'none';
       })
       .style('stroke', d => {
-        if (!d[0]) return 'none';
-        const styleProps = getNarrativeStyle(d[0].narrative);
+        if (!d || app.narrative === null) return 'none';
+        if (d.id !== app.narrative.id) return '#232323';
+        const styleProps = getNarrativeStyle(d.id);
         return styleProps.stroke;
       })
       .style('stroke-opacity', d => {
         if (app.narrative === null) return 0;
-        if (!d[0] || !d[0].narratives.find(n => n === app.narrative.id)) return 0.2;
+        if (!d || d.id !== app.narrative.id) return 0.2;
         return 1;
       })
-      .style('fill', 'none');
+      .style('fill', 'none')
+      .style('cursor', 'pointer')
+      .on('click', d => {
+        console.log(d)
+      });
 
     narrativesDom
+      .attr('d', d => sequenceLine(d.steps))
       .style('stroke', d => {
-        if (!d[0]) return 'none';
-        const styleProps = getNarrativeStyle(d[0].narrative);
+        if (!d || app.narrative === null) return 'none';
+        if (d.id !== app.narrative.id) return '#232323';
+        const styleProps = getNarrativeStyle(d.id);
         return styleProps.stroke;
       })
       .style('stroke-opacity', d => {
         if (app.narrative === null) return 0;
-        if (!d[0] || !d[0].narratives.find(n => n === app.narrative.id)) return 0.2;
+        if (!d || d.id !== app.narrative.id) return 0.2;
         return 1;
       })
   }
@@ -446,8 +451,8 @@ Stop and start the development process in terminal after you have added your tok
   */
   function renderDomain () {
     renderSites();
-    renderNarratives();
     renderEvents();
+    renderNarratives();
   }
   function renderSelectedAndHighlight () {
     renderSelected();

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -380,6 +380,11 @@ Stop and start the development process in terminal after you have added your tok
       .exit()
       .remove();
 
+    if (app.narrative !== null) {
+      d3.selectAll('#arrow path')
+        .style('fill', getNarrativeStyle(app.narrative.id).stroke);
+    }
+
     const getMarker = (d) => {
       if (!d || app.narrative === null) return 'none';
       if (d.id !== app.narrative.id) return 'url(#arrow-off)';

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -430,10 +430,11 @@ Stop and start the development process in terminal after you have added your tok
     }
 
     if (isNewAppProps) {
+      app.views = newApp.views;
       app.selected = newApp.selected;
       app.highlighted = newApp.highlighted;
+      app.mapAnchor = newApp.mapAnchor;
       app.narrative = newApp.narrative;
-      app.views = newApp.views;
     }
 
     if (isNewDomain || isNewAppProps) renderDomain();

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -17,6 +17,7 @@ export default function(newApp, ui, methods) {
   const app = {
     selected: [],
     highlighted: null,
+    narrative: null,
     views: Object.assign({}, newApp.views),
   }
 
@@ -362,7 +363,6 @@ Stop and start the development process in terminal after you have added your tok
       .exit()
       .remove();
 
-    let styleName
     narrativesDom
       .enter().append('path')
       .attr('class', 'narrative')
@@ -384,7 +384,24 @@ Stop and start the development process in terminal after you have added your tok
         const styleProps = getNarrativeStyle(d[0].narrative);
         return styleProps.stroke;
       })
+      .style('stroke-opacity', d => {
+        if (app.narrative === null) return 0;
+        if (!d[0] || app.narrative.id !== d[0].narrative) return 0.2;
+        return 1;
+      })
       .style('fill', 'none');
+
+    narrativesDom
+      .style('stroke', d => {
+        if (!d[0]) return 'none';
+        const styleProps = getNarrativeStyle(d[0].narrative);
+        return styleProps.stroke;
+      })
+      .style('stroke-opacity', d => {
+        if (app.narrative === null) return 0;
+        if (!d[0] || app.narrative.id !== d[0].narrative) return 0.2;
+        return 1;
+      })
   }
 
   /**
@@ -393,22 +410,25 @@ Stop and start the development process in terminal after you have added your tok
    */
   function update(newDomain, newApp) {
     updateSVG();
+    const isNewDomain = (hash(domain) !== hash(newDomain));
+    const isNewAppProps = (hash(app) !== hash(newApp));
 
-    if (hash(domain) !== hash(newDomain)) {
+    if (isNewDomain) {
       domain.locations = newDomain.locations;
       domain.narratives = newDomain.narratives;
       domain.categories = newDomain.categories;
       domain.sites = newDomain.sites;
-      renderDomain();
     }
 
-    if (hash(app) !== hash(newApp)) {
+    if (isNewAppProps) {
       app.selected = newApp.selected;
       app.highlighted = newApp.highlighted;
+      app.narrative = newApp.narrative;
       app.views = newApp.views;
-
-      renderSelectedAndHighlight();
     }
+
+    if (isNewDomain || isNewAppProps) renderDomain();
+    if (isNewAppProps) renderSelectedAndHighlight();
   }
 
   /**

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -57,7 +57,7 @@ export default function(newApp, ui, methods) {
     const map = L.map(id)
       .setView(center, zoom)
       .setMinZoom(10)
-      .setMaxZoom(18)
+      .setMaxZoom(19)
       .setMaxBounds(maxBoundaries)
 
     // NB: configure tile endpoint
@@ -383,6 +383,9 @@ Stop and start the development process in terminal after you have added your tok
     if (app.narrative !== null) {
       d3.selectAll('#arrow path')
         .style('fill', getNarrativeStyle(app.narrative.id).stroke);
+
+      d3.selectAll('.location-event-marker')
+        .style('fill-opacity', '0.1 !important')
     }
 
     const getMarker = (d) => {
@@ -407,7 +410,6 @@ Stop and start the development process in terminal after you have added your tok
       })
       .style('stroke', d => {
         if (!d || app.narrative === null) return 'none';
-        if (d.id !== app.narrative.id) return '#232323';
         const styleProps = getNarrativeStyle(d.id);
         return styleProps.stroke;
       })
@@ -432,7 +434,6 @@ Stop and start the development process in terminal after you have added your tok
       .attr('mid-marker', d => getMarker(d))
       .style('stroke', d => {
         if (!d || app.narrative === null) return 'none';
-        if (d.id !== app.narrative.id) return '#232323';
         const styleProps = getNarrativeStyle(d.id);
         return styleProps.stroke;
       })

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -377,7 +377,7 @@ Stop and start the development process in terminal after you have added your tok
 
   function renderNarratives() {
     const narrativesDom = svg.selectAll('.narrative')
-      .data(domain.narratives)
+      .data((app.narrative !== null) ? domain.narratives : [])
 
     narrativesDom
       .exit()
@@ -434,6 +434,7 @@ Stop and start the development process in terminal after you have added your tok
           .attr('marker-start', (d, j) => !j ? getMarker(n) :  'none')
           .attr('marker-end', getMarker(n))
           .attr('mid-marker', getMarker(n))
+          .on('click', () => methods.onSelectNarrative(n) )
 
       steps
           .attr('x1', d => getCoords(d).x + getSVGBoundaries().transformX)

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -157,7 +157,7 @@ Stop and start the development process in terminal after you have added your tok
 
     g.selectAll('.location').attr('transform', (d) => {
       const newPoint = projectPoint([+d.latitude, +d.longitude]);
-      return `translate(${newPoint.x + transformX},${newPoint.y + transformY})`;
+      return `translate(${newPoint.x},${newPoint.y})`;
     });
 
     const sequenceLine = d3.line()
@@ -279,9 +279,8 @@ Stop and start the development process in terminal after you have added your tok
       .enter().append('g')
       .attr('class', 'location')
       .attr('transform', (d) => {
-        d.LatLng = new L.LatLng(+d.latitude, +d.longitude);
-        return `translate(${lMap.latLngToLayerPoint(d.LatLng).x},
-                  ${lMap.latLngToLayerPoint(d.LatLng).y})`;
+        const newPoint = projectPoint([+d.latitude, +d.longitude]);
+        return `translate(${newPoint.x},${newPoint.y})`;
       })
       .on('click', (location) => {
         methods.onSelect(location.events);

--- a/src/js/timeline/timeline.js
+++ b/src/js/timeline/timeline.js
@@ -19,13 +19,13 @@ export default function(newApp, ui, methods) {
   const domain = {
     events: [],
     categories: [],
+    narratives: []
   }
   const app = {
-    selected: [],
-    highlighted: null,
-    zoomLevels: newApp.zoomLevels,
     timerange: newApp.timerange,
-    language: newApp.language
+    selected: [],
+    language: newApp.language,
+    zoomLevels: newApp.zoomLevels
   }
 
   // Dimension of the client
@@ -517,6 +517,8 @@ export default function(newApp, ui, methods) {
    * @param {Object} app: Redux state app subtree
    */
   function updateAxis() {
+    updateTimeRange();
+    
     scale.x = d3.scaleTime()
       .domain(app.timerange)
       .range([margin.left, WIDTH]);
@@ -544,35 +546,39 @@ export default function(newApp, ui, methods) {
    * @param {Object} newApp: object of time range and selected events
    */
   function update(newDomain, newApp) {
-    if (hash(domain) !== hash(newDomain)) {
+    const isNewDomain = (hash(domain) !== hash(newDomain));
+    const isNewAppProps = (hash(app) !== hash(newApp));
+
+    if (isNewDomain) {
       domain.categories = newDomain.categories;
       domain.events = newDomain.events;
-      updateAxis();
-      renderContext();
+      domain.narratives = newDomain.narratives;
     }
-    if (hash(app) !== hash(newApp)) {
+
+    if (isNewAppProps) {
       app.timerange = newApp.timerange;
       app.selected = newApp.selected.slice(0);
-      updateTimeRange();
-      renderTimeLabels();
-      renderEventsAndHighlight();
     }
+
+    if (isNewDomain || isNewAppProps) renderContent();
+    if (isNewAppProps) renderContext();
   }
 
   function renderContext() {
-    renderAxis();
     renderTimeControls();
     renderTimeLabels();
   }
 
-  function renderEventsAndHighlight() {
+  function renderContent() {
+    updateAxis();
+    renderAxis();
     renderEvents();
     renderHighlight();
   }
 
   function render() {
     renderContext();
-    renderEventsAndHighlight();
+    renderContent();
   }
 
   return {

--- a/src/js/timeline/timeline.js
+++ b/src/js/timeline/timeline.js
@@ -49,7 +49,10 @@ export default function(newApp, ui, methods) {
    * Create scales
    */
   const scale = {};
-  scale.x = d3.scaleTime();
+  scale.x = d3.scaleTime()
+      .domain(app.timerange)
+      .range([margin.left, WIDTH]);
+
   scale.y = d3.scaleOrdinal()
 
 
@@ -63,6 +66,14 @@ export default function(newApp, ui, methods) {
     .append('svg')
     .attr('width', WIDTH)
     .attr('height', HEIGHT);
+
+  dom.clip = dom.svg.append("svg:clipPath")
+    .attr("id", "clip")
+    .append("svg:rect")
+    .attr("x", margin.left)
+    .attr("y", 0)
+    .attr("width", WIDTH - margin.left)
+    .attr("height", HEIGHT - 25);
 
   dom.controls =
     d3.select(`#${ui.dom.timeline}`)
@@ -104,9 +115,10 @@ export default function(newApp, ui, methods) {
   /*
    * Plottable elements
    */
-  dom.dataset = dom.svg.append('g');
-  dom.events = dom.dataset.append('g');
-  dom.markers = dom.svg.append('g');
+
+  dom.body = dom.svg.append("g").attr("clip-path", "url(#clip)");
+  dom.events = dom.body.append('g');
+  dom.markers = dom.body.append('g');
 
 
   /*
@@ -321,6 +333,7 @@ export default function(newApp, ui, methods) {
     })
     .on('end', () => {
       toggleTransition(true);
+      app.timerange = scale.x.domain();
       methods.onUpdateTimerange(scale.x.domain());
     });
 
@@ -517,12 +530,6 @@ export default function(newApp, ui, methods) {
    * @param {Object} app: Redux state app subtree
    */
   function updateAxis() {
-    updateTimeRange();
-    
-    scale.x = d3.scaleTime()
-      .domain(app.timerange)
-      .range([margin.left, WIDTH]);
-
     const groupStep = (106 - 30) / domain.categories.length;
     let groupYs = Array.apply(null, Array(domain.categories.length));
     groupYs = groupYs.map((g, i) => {

--- a/src/js/timeline/timeline.js
+++ b/src/js/timeline/timeline.js
@@ -9,54 +9,49 @@ import {
   parseDate,
   formatterWithYear
 } from '../utilities';
+import hash from 'object-hash';
 import esLocale from '../data/es-MX.json';
 import copy from '../data/copy.json';
 
-export default function(app, ui, methods) {
+export default function(newApp, ui, methods) {
   d3.timeFormatDefaultLocale(esLocale);
 
-  const zoomLevels = app.zoomLevels;
-  let events = [];
-  let categories = [];
-  let selected = [];
-  let timerange = app.timerange;
+  const domain = {
+    events: [],
+    categories: [],
+  }
+  const app = {
+    selected: [],
+    highlighted: null,
+    zoomLevels: newApp.zoomLevels,
+    timerange: newApp.timerange,
+    language: newApp.language
+  }
+
+  // Dimension of the client
+  const WIDTH_CONTROLS = 100;
+  const HEIGHT = 140;
+  const boundingClient = d3.select(`#${ui.dom.timeline}`).node().getBoundingClientRect();
+  let WIDTH = boundingClient.width - WIDTH_CONTROLS;
+
+  // Highlight events with a larger white ring marker
+  const markerRadius = 15;
+
+  // NB: is it possible to do this with SCSS?
+  // A: Maybe, although we are using it programmatically here for now
+  const margin = { left: 120 };
 
   // Drag behavior
   let dragPos0;
   let transitionDuration = 500;
 
-  // Dimension of the client
-  const WIDTH_CONTROLS = 100;
-  const boundingClient = d3.select(`#${ui.dom.timeline}`).node().getBoundingClientRect();
-  let WIDTH = boundingClient.width - WIDTH_CONTROLS;
-  const HEIGHT = 140;
-  const markerRadius = 15;
-  // margin
-  // NB: is it possible to do this with SCSS?
-  // A: Maybe, although we are using it programmatically here for now
-  const mg = {
-    l: 120
-  };
-
   /**
    * Create scales
    */
   const scale = {};
-
-  scale.x = d3.scaleTime()
-    .domain(timerange)
-    .range([mg.l, WIDTH]);
-
-  // calculate group step between categories
-  const groupStep = (106 - 30) / categories.length;
-  const groupYs = new Array(categories.length);
-  groupYs.map((g, i) => {
-    return 30 + i * groupStep;
-  });
-
+  scale.x = d3.scaleTime();
   scale.y = d3.scaleOrdinal()
-    .domain(categories)
-    .range(groupYs);
+
 
   /**
    * Initilize SVG elements and groups
@@ -76,10 +71,10 @@ export default function(app, ui, methods) {
     .attr('width', WIDTH_CONTROLS)
     .attr('height', HEIGHT);
 
+
   /*
    * Axis group elements
    */
-
   dom.axis = {};
 
   dom.axis.x0 = dom.svg.append('g')
@@ -105,11 +100,14 @@ export default function(app, ui, methods) {
   dom.axis.label1 = dom.svg.append('text')
     .attr('class', 'timelabelF timeLabel');
 
+
   /*
    * Plottable elements
    */
   dom.dataset = dom.svg.append('g');
   dom.events = dom.dataset.append('g');
+  dom.markers = dom.svg.append('g');
+
 
   /*
    * Time Controls
@@ -125,9 +123,10 @@ export default function(app, ui, methods) {
   dom.zooms = dom.controls.append('g');
 
   dom.zooms.selectAll('.zoom-level-button')
-    .data(zoomLevels)
+    .data(app.zoomLevels)
     .enter().append('text')
     .attr('class', 'zoom-level-button');
+
 
   /*
    * Initialize axis function and element group
@@ -152,37 +151,8 @@ export default function(app, ui, methods) {
     d3.axisLeft(scale.y)
     .tickValues([]);
 
-  /*
-   * Setup drag behavior
-   */
-  const drag =
-    d3.drag()
-    .on('start', () => {
-      d3.event.sourceEvent.stopPropagation();
-      dragPos0 = d3.event.x;
-      toggleTransition(false);
-    })
-    .on('drag', () => {
-      const drag0 = scale.x.invert(dragPos0).getTime();
-      const dragNow = scale.x.invert(d3.event.x).getTime();
-      const timeShift = (drag0 - dragNow) / 1000;
+  updateAxis();
 
-      const newDomain0 = d3.timeSecond.offset(timerange[0], timeShift);
-      const newDomainF = d3.timeSecond.offset(timerange[1], timeShift);
-
-      scale.x.domain([newDomain0, newDomainF])
-      render();
-    })
-    .on('end', () => {
-      toggleTransition(true);
-      methods.onUpdateTimerange(scale.x.domain());
-    });
-
-  /*
-   * SVG groups for marker
-   */
-
-  dom.markers = dom.svg.append('g');
 
   /**
    * Adapt dimensions when resizing
@@ -191,6 +161,7 @@ export default function(app, ui, methods) {
     return d3.select(`#${ui.dom.timeline}`).node()
       .getBoundingClientRect().width;
   }
+
 
   /**
    * Resize timeline one window resice
@@ -201,14 +172,15 @@ export default function(app, ui, methods) {
         WIDTH = getCurrentWidth() - WIDTH_CONTROLS;
 
         dom.svg.attr('width', WIDTH);
-        scale.x.range([mg.l, WIDTH]);
-        axis.y.tickSize(WIDTH - mg.l);
+        scale.x.range([margin.left, WIDTH]);
+        axis.y.tickSize(WIDTH - margin.left);
         dom.axis.y.attr('transform', `translate(${WIDTH}, 0)`)
         render(null);
       }
     });
   }
   addResizeListener();
+
 
   /**
    * Return which color event circle should be based on incident type
@@ -218,6 +190,7 @@ export default function(app, ui, methods) {
     return methods.getCategoryColor(eventPoint.category);
   }
 
+
   /**
    * Given an event, get all the filtered events that happen simultaneously
    * @param {object} eventPoint: regular eventPoint data
@@ -225,9 +198,10 @@ export default function(app, ui, methods) {
   function getAllEventsAtOnce(eventPoint) {
     const timestamp = eventPoint.timestamp;
     const category = eventPoint.category;
-    return events
+    return domain.events
       .filter(event => (event.timestamp === timestamp && category === event.category))
   }
+
 
   /*
    * Get y height of eventPoint, considering the ordinal Y scale
@@ -237,6 +211,7 @@ export default function(app, ui, methods) {
     const yGroup = eventPoint.category;
     return scale.y(yGroup);
   }
+
 
   /*
    * Get x position of eventPoint, considering the time scale
@@ -250,6 +225,7 @@ export default function(app, ui, methods) {
     return (scale.x.domain()[1].getTime() - scale.x.domain()[0].getTime()) / 60000;
   }
 
+
   /*
    * Given a number of minutes, calculate the width based on current scale.x
    * @param {number} minutes: number of minutes
@@ -259,8 +235,12 @@ export default function(app, ui, methods) {
     return (minutes * WIDTH) / allMins;
   }
 
+
+  /*
+  * TODO: Highlight zoom level based on time range selected
+  */
   function highlightZoomLevel(zoom) {
-    zoomLevels.forEach((level) => {
+    app.zoomLevels.forEach((level) => {
       if (level.label === zoom.label) {
         level.active = true;
       } else {
@@ -271,6 +251,7 @@ export default function(app, ui, methods) {
     dom.zooms.selectAll('text')
       .classed('active', level => level.active);
   }
+
 
   /**
    * Apply zoom level to timeline
@@ -288,6 +269,7 @@ export default function(app, ui, methods) {
     scale.x.domain([domain0, domainF]);
     methods.onUpdateTimerange(scale.x.domain());
   }
+
 
   /**
    * Shift time range by moving forward or backwards
@@ -316,6 +298,33 @@ export default function(app, ui, methods) {
     transitionDuration = (isTransition) ? 500 : 0;
   }
 
+
+  /*
+   * Setup drag behavior
+   */
+  const drag = d3.drag()
+    .on('start', () => {
+      d3.event.sourceEvent.stopPropagation();
+      dragPos0 = d3.event.x;
+      toggleTransition(false);
+    })
+    .on('drag', () => {
+      const drag0 = scale.x.invert(dragPos0).getTime();
+      const dragNow = scale.x.invert(d3.event.x).getTime();
+      const timeShift = (drag0 - dragNow) / 1000;
+
+      const newDomain0 = d3.timeSecond.offset(app.timerange[0], timeShift);
+      const newDomainF = d3.timeSecond.offset(app.timerange[1], timeShift);
+
+      scale.x.domain([newDomain0, newDomainF]);
+      render();
+    })
+    .on('end', () => {
+      toggleTransition(true);
+      methods.onUpdateTimerange(scale.x.domain());
+    });
+
+
   /**
    * Highlight event circle on hover
    */
@@ -324,6 +333,7 @@ export default function(app, ui, methods) {
       .attr('r', 7)
       .classed('mouseover', true);
   }
+
 
   /**
    * Unhighlight event when mouse out
@@ -334,11 +344,12 @@ export default function(app, ui, methods) {
       .classed('mouseover', false);
   }
 
+
   /**
    * It automatically sets brush timeline to a domain set by the params
    */
   function updateTimeRange() {
-    scale.x.domain(timerange);
+    scale.x.domain(app.timerange);
     axis.x0.scale(scale.x);
     axis.x1.scale(scale.x);
   }
@@ -351,23 +362,24 @@ export default function(app, ui, methods) {
     dom.axis.label0
       .attr('x', 5)
       .attr('y', 15)
-      .text(formatterWithYear(timerange[0]));
+      .text(formatterWithYear(app.timerange[0]));
 
     dom.axis.label1
       .attr('x', WIDTH - 5)
       .attr('y', 15)
-      .text(formatterWithYear(timerange[1]))
+      .text(formatterWithYear(app.timerange[1]))
       .style('text-anchor', 'end');
   }
 
+
   /**
-   * Makes a circular rinig mark in one particular location at a time
+   * Makes a circular ring mark in all selected events
    * @param {object} eventPoint: object with eventPoint data (time, loc, tags)
    */
   function renderHighlight() {
     const markers = dom.markers
       .selectAll('circle')
-      .data(selected);
+      .data(app.selected);
 
     markers
       .enter()
@@ -382,13 +394,14 @@ export default function(app, ui, methods) {
     markers.exit().remove();
   }
 
+
   /**
    * Return event circles of different groups
    */
   function renderEvents() {
     const eventsDom = dom.events
       .selectAll('.event')
-      .data(events, d => d.id);
+      .data(domain.events, d => d.id);
 
     eventsDom
       .exit()
@@ -417,6 +430,7 @@ export default function(app, ui, methods) {
       .attr('r', 5);
   }
 
+
   /**
    * Render axis on timeline and viewbox boundaries
    */
@@ -437,7 +451,7 @@ export default function(app, ui, methods) {
       .duration(transitionDuration)
       .call(axis.x1);
 
-    axis.y.tickSize(WIDTH - mg.l);
+    axis.y.tickSize(WIDTH - margin.left);
 
     dom.axis.y
       .call(axis.y)
@@ -453,12 +467,13 @@ export default function(app, ui, methods) {
       .attr('x', scale.x.range()[1] - 5);
   }
 
+
   /**
    * Render left and right time shifting controls
    */
   function renderTimeControls() {
     const zoomLabels = copy[app.language].timeline.zooms;
-    zoomLevels.forEach((level, i) => {
+    app.zoomLevels.forEach((level, i) => {
       level.label = zoomLabels[i];
     });
 
@@ -495,49 +510,72 @@ export default function(app, ui, methods) {
       .on('click', zoom => applyZoom(zoom));
   }
 
+
   /**
    * Updates data displayed by this timeline, but only render if necessary
    * @param {Object} domain: Redux state domain subtree
    * @param {Object} app: Redux state app subtree
    */
-  function updateAxis(domain) {
-    const categories = domain.categories
-    const groupStep = (106 - 30) / categories.length;
-    let groupYs = Array.apply(null, Array(categories.length));
+  function updateAxis() {
+    scale.x = d3.scaleTime()
+      .domain(app.timerange)
+      .range([margin.left, WIDTH]);
+
+    const groupStep = (106 - 30) / domain.categories.length;
+    let groupYs = Array.apply(null, Array(domain.categories.length));
     groupYs = groupYs.map((g, i) => {
       return 30 + i * groupStep;
     });
 
     scale.y = d3.scaleOrdinal()
-      .domain(categories)
+      .domain(domain.categories)
       .range(groupYs);
 
     axis.y =
       d3.axisLeft(scale.y)
-        .tickValues(categories.map(c => c.category));
+        .tickValues(domain.categories.map(c => c.category));
   }
 
-  function update(domain, app) {
-    updateAxis(domain);
-    renderAxis();
 
-    events = domain.events;
-    timerange = app.timerange;
-    selected = app.selected.slice(0);
-    updateTimeRange();
+  /**
+   * Updates displayable data on the timeline: events, selected and
+   * potentially adjusts time range
+   * @param {Object} newDomain: object of arrays of events and categories
+   * @param {Object} newApp: object of time range and selected events
+   */
+  function update(newDomain, newApp) {
+    if (hash(domain) !== hash(newDomain)) {
+      domain.categories = newDomain.categories;
+      domain.events = newDomain.events;
+      updateAxis();
+      renderContext();
+    }
+    if (hash(app) !== hash(newApp)) {
+      app.timerange = newApp.timerange;
+      app.selected = newApp.selected.slice(0);
+      updateTimeRange();
+      renderTimeLabels();
+      renderEventsAndHighlight();
+    }
   }
 
-  function render() {
+  function renderContext() {
     renderAxis();
     renderTimeControls();
     renderTimeLabels();
+  }
 
+  function renderEventsAndHighlight() {
     renderEvents();
     renderHighlight();
   }
 
+  function render() {
+    renderContext();
+    renderEventsAndHighlight();
+  }
+
   return {
     update,
-    render,
   };
 }

--- a/src/js/utilities.js
+++ b/src/js/utilities.js
@@ -44,6 +44,13 @@ export function capitalizeFirstLetter(string) {
     return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
+export function trimAndEllipse(string, stringNum) {
+  if (string.length > stringNum) {
+    return string.substring(0, 120) + '...'
+  }
+  return string;
+}
+
 /**
 * Return a Date object given a datetime string of the format: "2016-09-10T07:00:00"
 * @param {string} datetime

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -32,6 +32,7 @@ function updateSelected(appState, action) {
 }
 
 function updateNarrative(appState, action) {
+  console.log('this happens')
   if (action.narrative === null) {
     return Object.assign({}, appState, {
       narrative: action.narrative,
@@ -43,7 +44,7 @@ function updateNarrative(appState, action) {
     // Add some margin to the datetime extent
     minDate = minDate - ((maxDate - minDate) / 20);
     maxDate = maxDate + ((maxDate - minDate) / 20);
-    return appState;
+
     return Object.assign({}, appState, {
       narrative: action.narrative,
       filters: Object.assign({}, appState.filters, {

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -43,7 +43,7 @@ function updateNarrative(appState, action) {
     // Add some margin to the datetime extent
     minDate = minDate - ((maxDate - minDate) / 20);
     maxDate = maxDate + ((maxDate - minDate) / 20);
-
+    return appState;
     return Object.assign({}, appState, {
       narrative: action.narrative,
       filters: Object.assign({}, appState.filters, {

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -32,7 +32,6 @@ function updateSelected(appState, action) {
 }
 
 function updateNarrative(appState, action) {
-  console.log('this happens')
   if (action.narrative === null) {
     return Object.assign({}, appState, {
       narrative: action.narrative,

--- a/src/reducers/schema/eventSchema.js
+++ b/src/reducers/schema/eventSchema.js
@@ -11,7 +11,7 @@ const eventSchema = Joi.object().keys({
     longitude:        Joi.string().allow('').required(),
     type:             Joi.string().allow(''),
     category:         Joi.string().required(),
-    narrative:        Joi.string().allow(''),
+    narratives:       Joi.array(),
     sources:          Joi.array(),
     tags:             Joi.string().allow(''),
     comments:         Joi.string().allow(''),

--- a/src/scss/map.scss
+++ b/src/scss/map.scss
@@ -27,8 +27,12 @@
     z-index: $hidden;
   }
   &.show {
-      z-index: $map;
+    z-index: $map;
   }
+  &.narrative-mode {
+    left: 0;
+  }
+  
   .event {
     fill: $event_default;
     cursor: pointer;

--- a/src/scss/map.scss
+++ b/src/scss/map.scss
@@ -155,7 +155,7 @@
   fill: $event_default;
   stroke-width: 0;
   transition: 0.2s ease;
-  fill-opacity: 0.8;
+  /*fill-opacity: 0.8;*/
   cursor: pointer;
 
   &:hover {

--- a/src/scss/map.scss
+++ b/src/scss/map.scss
@@ -32,11 +32,15 @@
   &.narrative-mode {
     left: 0;
   }
-  
+
   .event {
     fill: $event_default;
     cursor: pointer;
     opacity: 0.45;
+  }
+
+  .narrative {
+    cursor: pointer;
   }
 
   .link {

--- a/src/scss/narrativecard.scss
+++ b/src/scss/narrativecard.scss
@@ -4,9 +4,9 @@ NARRATIVE INFO
 .narrative-info {
   position: fixed;
   top: 10px;
-  left: 130px;
+  left: 10px;
   height: auto;
-  width: 270px;
+  width: 370px;
   box-sizing: border-box;
   padding: 15px;
   max-height: calc(100% - 250px);
@@ -23,6 +23,10 @@ NARRATIVE INFO
 
   h3 {
     font-size: $large;
+    font-family: 'Merriweather', 'Georgia', serif;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    font-weight: 100;
   }
 
   p {

--- a/src/scss/narrativecard.scss
+++ b/src/scss/narrativecard.scss
@@ -29,6 +29,13 @@ NARRATIVE INFO
     font-weight: 100;
   }
 
+  h6 {
+    margin: 10px 0;
+    i {
+      font-size: $normal;
+    }
+  }
+
   p {
     font-family: 'Lato', 'Helvetica', sans-serif;
     font-size: $normal;

--- a/src/scss/timeline.scss
+++ b/src/scss/timeline.scss
@@ -22,6 +22,10 @@
     }
   }
 
+  &.narrative-mode {
+    left: 0;
+  }
+
   .timeline-header {
     height: 0px;
     width: 100%;

--- a/src/scss/toolbar.scss
+++ b/src/scss/toolbar.scss
@@ -168,6 +168,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    flex-direction: column;
     height: 60px;
     width: 110px;
     padding: 5px 0 5px 0;
@@ -454,7 +455,7 @@
       height: 140px;
       line-height: 140px;
       width: 100%;
-      padding: 0;
+      padding: 10px;
       border: 1px solid $offwhite;
       background-size: 100%;
       color: $offwhite;
@@ -469,6 +470,10 @@
       &:hover {
         transition: 0.2s ease;
         letter-spacing: 0.15em;
+      }
+
+      p {
+        text-transform: none;
       }
     }
 
@@ -515,10 +520,10 @@
       height: 60px;
       padding: 0;
 
-      .tab-caption {
+      /*.tab-caption {
         transition: 0.2s ease;
         opacity: 0;
-      }
+      }*/
 
       &:hover {
         .tab-caption {

--- a/src/scss/toolbar.scss
+++ b/src/scss/toolbar.scss
@@ -9,6 +9,10 @@
   z-index: $header;
   background: $midgrey;
 
+  &.narrative-mode {
+    left: -110px;
+  }
+
   .toolbar {
     position: relative;
     width: 110px;
@@ -292,37 +296,6 @@
     }
   }
 
-  .people-tab {
-    width: 50%;
-    font-family: 'Lato', Helvetica, sans-serif;
-    font-size: $normal;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-
-    svg {
-      transform: translate(-2px,0)scale(0.6);
-      &:hover {
-        transition: 0.2s ease;
-        stroke: $offwhite;
-      }
-    }
-
-    &.react-tabs__tab--selected {
-      svg circle,
-      svg path {
-        stroke: $offwhite;
-      }
-    }
-
-    svg circle,
-    svg path {
-      transition: 0.2s ease;
-      fill: none;
-      stroke: $midwhite;
-      stroke-width: 3;
-    }
-  }
-
   .react-tabs__tab-list {
     height: 40px;
     overflow: hidden;
@@ -361,6 +334,14 @@
     ul {
       height: 0;
       margin: 0;
+    }
+
+    .panel-header {
+      visibility: hidden;
+
+      .caret {
+        transform: translate(8px, 5px)rotate(225deg);
+      }
     }
   }
 
@@ -491,7 +472,7 @@
       }
     }
 
-    &:first-child {
+    /*&:first-child {
       button { background-image: url("/static/archive/img/scene01.jpg"); }
     }
     &:nth-child(2n) {
@@ -503,114 +484,7 @@
 
     &.back-to-map {
         button { background-image: url("/static/archive/img/map.jpg"); }
-    }
-  }
-}
-
-.taggroup-wrapper {
-  margin-top: 30px;
-  z-index: 10;
-  border-bottom: none;
-
-  &:last-child {
-    margin-bottom: 0;
-    border-bottom: 1px solid rgba(white, 0);
-  }
-
-  &:hover {
-    transition: 0.1s ease;
-  }
-
-  .collapsible-item {
-    width: calc(100% - 32px);
-    float: left;
-  }
-
-  .taggroup-header {
-    width: 100%;
-    margin: 0;
-    font-size: $large;
-
-    h2::first-letter {
-      margin-top: 0;
-    }
-  }
-
-  .taggroup-content {
-    width: 100%;
-    display: inline-block;
-    padding-left: 10px;
-    box-sizing: border-box;
-    transition: 0.2s ease;
-
-    .tagsubgroup-wrapper {
-      border: none;
-      border-bottom: 1px solid rgba(white, 0.25);
-      &:first-letter {
-        text-transform: uppercase;
-      }
-
-      &:last-child {
-        border-bottom: 0;
-      }
-
-      .tagsubgroup-header {
-        cursor: pointer;
-      }
-
-      &.folded {
-        .tagsubgroup-content {
-          overflow: hidden;
-          padding: 0 10px;
-          transition: 0.2s ease;
-          height: 0;
-          border-top: 0;
-        }
-      }
-
-      .item {
-        overflow: auto;
-        min-height: 32px;
-        height: auto;
-
-        span {
-          height: auto;
-        }
-      }
-    }
-
-    .tag-filter {
-      outline: none;
-      border: 0;
-      background: none;
-      color: $offwhite;
-      margin-left: 20px;
-      width: calc(100% - 20px);
-      box-sizing: border-box;
-      padding: 0;
-      font-size: $normal;
-      font-weight: 400;
-      text-align: left;
-      cursor: pointer;
-      border: 1px solid $black;
-      border-bottom: 1px solid rgba(white, 0.25);
-      &:first-letter {
-        text-transform: uppercase;
-      }
-
-      &:last-child {
-        border-bottom: 1px solid rgba(white, 0);
-      }
-    }
-  }
-
-  &.folded {
-    .filter-list-content {
-      padding: 0 10px;
-      border-top: 0;
-      transition: 0.2s ease;
-      height: 0;
-    }
+    }*/
   }
 }
 

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -163,7 +163,6 @@ export const selectLocations = createSelector(
 export const selectSelected = createSelector(
   [getSelected, getSources],
   (selected, sources) => {
-    console.log(selected, sources)
     if (selected.length === 0) {
       return []
     }

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -95,16 +95,18 @@ export const selectNarratives = createSelector(
       events.forEach((evt) => {
         const isTagged = isTaggedIn(evt, tagFilters) || isNoTags(tagFilters);
         const isTimeRanged = isTimeRangedIn(evt, timeRange);
-        const isInNarrative =  evt.narrative;
+        const isInNarrative =  evt.narratives.length > 0;
 
-        if (!narratives[evt.narrative]) {
-          narratives[evt.narrative] = { id: evt.narrative, steps: [], byId: {} };
-        }
+        evt.narratives.map(narrative => {
+          if (!narratives[narrative]) {
+            narratives[narrative] = { id: narrative, steps: [], byId: {} };
+          }
 
-        if (/*isTimeRanged && isTagged && */isInNarrative) {
-          narratives[evt.narrative].steps.push(evt);
-          narratives[evt.narrative].byId[evt.id] = { next: null, prev: null };
-        }
+          if (isInNarrative) {
+            narratives[narrative].steps.push(evt);
+            narratives[narrative].byId[evt.id] = { next: null, prev: null };
+          }
+        })
       });
 
       Object.keys(narratives).forEach((key) => {
@@ -161,6 +163,7 @@ export const selectLocations = createSelector(
 export const selectSelected = createSelector(
   [getSelected, getSources],
   (selected, sources) => {
+    console.log(selected, sources)
     if (selected.length === 0) {
       return []
     }

--- a/src/store/initial.js
+++ b/src/store/initial.js
@@ -115,11 +115,17 @@ const initial = {
 
       narratives: {
         default: {
-          style: 'solid',                  // ['dotted', 'solid']
-          opacity: 0.5,                     // range between 0 and 1
-          stroke: 'transparent',               // Any hex or rgb code
-          strokeWidth: 2
+          style: 'dotted',                  // ['dotted', 'solid']
+          opacity: 0.9,                     // range between 0 and 1
+          stroke: 'red',               // Any hex or rgb code
+          strokeWidth: 3
         },
+        narrative_1: {
+          style: 'solid',                  // ['dotted', 'solid']
+          opacity: 0.4,                     // range between 0 and 1
+          stroke: '#f18f01',               // Any hex or rgb code
+          strokeWidth: 3
+        }
       }
     },
     dom: {

--- a/src/store/initial.js
+++ b/src/store/initial.js
@@ -115,7 +115,7 @@ const initial = {
 
       narratives: {
         default: {
-          style: 'dotted',                  // ['dotted', 'solid']
+          style: 'solid',                  // ['dotted', 'solid']
           opacity: 0.9,                     // range between 0 and 1
           stroke: 'red',               // Any hex or rgb code
           strokeWidth: 3


### PR DESCRIPTION
This PR implements a more focused narrative mode, closes #42 and closes #43. 
The user can now select a Narrative in the toolbar. Selecting a narrative:
* Foregrounds a curated sequence of events that are bundled together thematically around an articulated narrative.
* Hides the toolbar to help the user focus on that sequence.
* Displays a Narrative card that summarizes the sequence and allows to move from event to event.
* Displays a styled sequence of arrows on the map from event to event in the sequence.
* Displays a toned down sequence of arrows associated with other available narratives. 
* When closing the narrative card, the user goes back to simple exploratory mode: the Toolbar displays again, and narrative arrow lines become hidden.