### PR TITLE
Hot fix: map snappiness

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -39,7 +39,7 @@ class Map extends React.Component {
       // Fly to first  of events selected
       const eventPoint = (nextProps.app.selected.length > 0) ? nextProps.app.selected[0] : null;
 
-      if (eventPoint.latitude && eventPoint.longitude) {
+      if (eventPoint !== null && eventPoint.latitude && eventPoint.longitude) {
         this.map.flyTo([eventPoint.latitude, eventPoint.longitude]);
       }
     }

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -40,7 +40,7 @@ class Map extends React.Component {
       const eventPoint = (nextProps.app.selected.length > 0) ? nextProps.app.selected[0] : null;
 
       if (eventPoint !== null && eventPoint.latitude && eventPoint.longitude) {
-        this.map.flyTo([eventPoint.latitude, eventPoint.longitude]);
+        this.map.setView([eventPoint.latitude, eventPoint.longitude]);
       }
     }
   }  

--- a/src/components/MapEvents.jsx
+++ b/src/components/MapEvents.jsx
@@ -46,7 +46,6 @@ class MapEvents extends React.Component {
       <g
         className="location"
         transform={`translate(${x}, ${y})`}
-        style={{ transition: 'transform 0.1s' }}
       >
         {Object.keys(eventsByCategory).map(cat => {
           return this.renderCategory(eventsByCategory[cat], cat)

--- a/src/components/MapSelectedEvents.jsx
+++ b/src/components/MapSelectedEvents.jsx
@@ -13,7 +13,6 @@ class MapSelectedEvents extends React.Component {
 
   renderMarker (event) {
     const { x, y } = this.projectPoint([event.latitude, event.longitude]);
-    console.log(x, y)
     return (
       <g
         className="location-marker"

--- a/src/scss/map.scss
+++ b/src/scss/map.scss
@@ -59,7 +59,6 @@
     font-family: 'Lato', Helvetica, sans-serif;
     border: rgba($black,0.6);
     letter-spacing: 0.05em;
-    transition: transform 0.1s;
 
     &::before {
       border-top-color: rgba($black,0.6);
@@ -169,12 +168,9 @@
 .location-event-marker {
   fill: $event_default;
   stroke-width: 0;
-  transition: 0.2s ease;
-  /*fill-opacity: 0.8;*/
   cursor: pointer;
 
   &:hover {
-    transition: 0.2s ease;
     fill-opacity: 1;
   }
 }


### PR DESCRIPTION
This PR introduces two quick fixes.

* Closing a Card in the CardStack resulted in an error as the map was trying to flyTo a null object.
* map.flyTo triggers unexpected behavior when the flyTo target is very close to the current center of the map view. In those cases, the map simply snaps into the new center, bypassing the events of move, zoom and viewReset. Since those events are listened to in order to realign the SVG layers, this results in a misalignment between map and SVG layers. We swap here flyTo for setView, which does adequately realign layers performing a much more subtle animation.