### PR TITLE
Step styles

### DIFF
--- a/src/components/Md.jsx
+++ b/src/components/Md.jsx
@@ -12,6 +12,9 @@ class Md extends React.Component {
     fetch(this.props.path)
       .then(resp => resp.text())
       .then(text => {
+        if (text.length <= 0)
+          throw new Error()
+
         this.setState({ md: marked(text) })
       })
       .catch(err => {
@@ -34,7 +37,7 @@ class Md extends React.Component {
 
 Md.propTypes = {
   loader: PropTypes.func,
-  unloader: PropTypes.func,
+  unloader: PropTypes.func.isRequired,
   path: PropTypes.string.isRequired
 }
 

--- a/src/components/SourceOverlay.jsx
+++ b/src/components/SourceOverlay.jsx
@@ -7,15 +7,21 @@ import NoSource from './presentational/NoSource'
 // TODO: move render functions into presentational components
 
 function SourceOverlay ({ source, onCancel }) {
+  function renderError() {
+    return (
+      <NoSource failedUrls={["NOT ALL SOURCES AVAILABLE IN APPLICATION YET"]} />
+    )
+  }
+
   function renderImage(path) {
     return (
       <div className='source-image-container'>
-        <Img
-          className='source-image'
-          src={path}
-          loader={<Spinner />}
-          unloader={<NoSource failedUrls={source.paths} />}
-        />
+      <Img
+      className='source-image'
+      src={path}
+      loader={<Spinner />}
+      unloader={<NoSource failedUrls={source.paths} />}
+      />
       </div>
     )
   }
@@ -45,11 +51,6 @@ function SourceOverlay ({ source, onCancel }) {
     )
   }
 
-  function renderError() {
-    return (
-      <NoSource failedUrls={["NOT ALL SOURCES AVAILABLE IN APPLICATION YET"]} />
-    )
-  }
 
   function renderNoSupport(ext) {
     return (

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -29,7 +29,7 @@ class Toolbar extends React.Component {
   }
 
   renderSearch() {
-    if (this.props.features.USE_SEARCH) {
+    if (process.env.features.USE_SEARCH) {
       return (
         <TabPanel>
           <Search
@@ -70,7 +70,7 @@ class Toolbar extends React.Component {
   }
 
   renderToolbarTagPanel() {
-    if (this.props.features.USE_TAGS &&
+    if (process.env.features.USE_TAGS &&
       this.props.tags.children) {
       return (
         <TabPanel>

--- a/src/reducers/schema/eventSchema.js
+++ b/src/reducers/schema/eventSchema.js
@@ -12,6 +12,7 @@ const eventSchema = Joi.object().keys({
     type:             Joi.string().allow(''),
     category:         Joi.string().required(),
     narratives:       Joi.array(),
+    narrative___movements: Joi.array(),
     sources:          Joi.array(),
     tags:             Joi.string().allow(''),
     comments:         Joi.string().allow(''),

--- a/src/reducers/schema/eventSchema.js
+++ b/src/reducers/schema/eventSchema.js
@@ -12,11 +12,13 @@ const eventSchema = Joi.object().keys({
     type:             Joi.string().allow(''),
     category:         Joi.string().required(),
     narratives:       Joi.array(),
-    narrative___movements: Joi.array(),
     sources:          Joi.array(),
     tags:             Joi.string().allow(''),
     comments:         Joi.string().allow(''),
     timestamp:        Joi.string().required(),
+
+    // nested
+    narrative___stepStyles: Joi.array(),
 });
 
 export default eventSchema;

--- a/src/store/initial.js
+++ b/src/store/initial.js
@@ -89,10 +89,6 @@ const initial = {
         duration: 10,
         active: false
       }],
-    features: {
-      USE_TAGS: process.env.features.USE_TAGS,
-      USE_SEARCH: process.env.features.USE_SEARCH
-    },
     flags: {
       isFetchingDomain: false,
       isFetchingSources: false,
@@ -120,16 +116,22 @@ const initial = {
 
       narratives: {
         default: {
-          style: 'solid',                  // ['dotted', 'solid']
-          opacity: 0.9,                     // range between 0 and 1
-          stroke: 'red',               // Any hex or rgb code
+          opacity: 0.9,
+          stroke: 'red',
           strokeWidth: 3
         },
         narrative_1: {
-          style: 'solid',                  // ['dotted', 'solid']
-          opacity: 0.4,                     // range between 0 and 1
-          stroke: '#f18f01',               // Any hex or rgb code
+          opacity: 0.4,
+          stroke: '#f18f01',
           strokeWidth: 3
+        },
+        // process.env.features.NARRATIVE_STEP_STYLES
+        stepStyles: {
+          Physical: {
+            stroke: 'yellow',
+            strokeWidth: 3,
+            opacity: 0.9,
+          }
         }
       }
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,6 @@
 const webpack = require('webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const userConfig = require('./config');
-const userConfigJSON = {};
 
 const devMode = process.env.NODE_ENV !== 'production';
 const path = require('path');
@@ -10,8 +8,16 @@ const path = require('path');
 const APP_DIR = path.resolve(__dirname, './src');
 const BUILD_DIR = path.resolve(__dirname, './build');
 
-for (const k in userConfig) {
-  userConfigJSON[k] = JSON.stringify(userConfig[k]);
+/** env variables from config.js */
+const envConfig = require('./config');
+const userConfig = {}
+const userFeatures = {}
+for (const k in envConfig) {
+  userConfig[k] = JSON.stringify(envConfig[k]);
+}
+
+for (const k in envConfig['features']) {
+  userFeatures[k] = JSON.stringify(envConfig['features'][k])
 }
 
 const config = {
@@ -59,14 +65,9 @@ const config = {
   plugins: [
     new webpack.DefinePlugin({
       'process.env': {
-        ...userConfigJSON,
+        ...userConfig,
         'NODE_ENV': JSON.stringify('production'),
-        'features': {
-          'USE_TAGS': JSON.stringify(userConfig.features.USE_TAGS),
-          'USE_SEARCH': JSON.stringify(userConfig.features.USE_SEARCH),
-          'USE_SITES': JSON.stringify(userConfig.features.USE_SITES),
-          'USE_SOURCES': JSON.stringify(userConfig.features.USE_SOURCES)
-        }
+        'features': userFeatures
       }
     }),
     new MiniCssExtractPlugin({


### PR DESCRIPTION
Enables optional styling per step in narratives, rather than requiring that one step style dictate all steps in a given narrative.

If `NARRATIVE_STEP_STYLES` is enabled in config.js, the application looks to `state.ui.narrative.stepStyles` for the style per step in each narrative.

The style per step is specified in each event. Along with the `narratives` array, there is an equal length array called `narrative___stepStyles` that contains the titles of the styles that should be drawn for the step from the given event to the next in each narrative. `narrative__stepStyles` needs to be an array, as the step from one event to the next may be styled differently across narratives (if the event exists in multiple narratives).

`narrative___stepStyles` is not a great name. In future PRs, we should move towards decoupling attribute names coming from the server and items on data structures in Timemap as much as possible, so that the name of the attribute in the event object coming from the server does not need to directly match the name used in the frontend, but rather can be configured if necessary.