### PR TITLE
Topic/refactor event styles

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -103,7 +103,6 @@ class Dashboard extends React.Component {
           }}
         />
         <Map
-          mapId='map'
           methods={{
             onSelect: this.handleSelect,
             onSelectNarrative: this.setNarrative,

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -168,8 +168,10 @@ class Map extends React.Component {
    * components in the <g/> div.
    */
   styleLocation(location) {
+    const noEvents = location.events.length
     return [
-      { fill: 'orange' },
+      null,
+      () => noEvents > 1 ? <text className='location-count' dx='-3' dy='4'>{noEvents}</text> : null
     ]
   }
 

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -162,6 +162,7 @@ class Map extends React.Component {
       <MapEvents
         svg={this.svgRef.current}
         locations={this.props.domain.locations}
+        styleLocation={(loc) => ({ /* TODO: add styles by location */ })}
         categories={this.props.domain.categories}
         map={this.map}
         mapTransformX={this.state.mapTransformX}

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -165,9 +165,10 @@ class Map extends React.Component {
    * necessary. The function should return a regular style object.
    */
   styleLocation(location) {
-    return {
-      fill: 'orange'
-    }
+    return [
+      { fill: 'orange' },
+      () => <text>ciao</text>
+    ]
   }
 
   renderEvents() {

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -25,6 +25,7 @@ class Map extends React.Component {
       mapTransformX: 0,
       mapTransformY: 0
     }
+    this.styleLocation = this.styleLocation.bind(this)
   }
 
   componentDidMount(){
@@ -157,12 +158,24 @@ class Map extends React.Component {
     );
   }
 
+  /**
+   * Determines additional styles on the <circle> for each location.
+   * A location consists of an array of events (location.events). The function
+   * also has full access to the domain and redux state to derive values if
+   * necessary. The function should return a regular style object.
+   */
+  styleLocation(location) {
+    return {
+      fill: 'orange'
+    }
+  }
+
   renderEvents() {
     return (
       <MapEvents
         svg={this.svgRef.current}
         locations={this.props.domain.locations}
-        styleLocation={(loc) => ({ /* TODO: add styles by location */ })}
+        styleLocation={this.styleLocation}
         categories={this.props.domain.categories}
         map={this.map}
         mapTransformX={this.state.mapTransformX}

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -51,7 +51,7 @@ class Map extends React.Component {
      * Creates a Leaflet map and a tilelayer for the map background
      */
     const map =
-      L.map(this.props.mapId)
+      L.map(this.props.ui.dom.map)
         .setView(this.props.app.mapAnchor, 14)
         .setMinZoom(7)
         .setMaxZoom(18)
@@ -104,7 +104,7 @@ class Map extends React.Component {
   }
 
   getClientDims() {
-    const boundingClient = document.querySelector(`#${this.props.mapId}`).getBoundingClientRect();
+    const boundingClient = document.querySelector(`#${this.props.ui.dom.map}`).getBoundingClientRect();
 
     return {
       width: boundingClient.width,
@@ -112,7 +112,7 @@ class Map extends React.Component {
     }
   }
 
-  renderSVG() {
+  renderTiles() {
     const pane = this.map.getPanes().overlayPane;
     const { width, height } = this.getClientDims();
 
@@ -160,14 +160,16 @@ class Map extends React.Component {
 
   /**
    * Determines additional styles on the <circle> for each location.
-   * A location consists of an array of events (location.events). The function
+   * A location consists of an array of events (see selectors). The function
    * also has full access to the domain and redux state to derive values if
-   * necessary. The function should return a regular style object.
+   * necessary. The function should return an array, where the value at the
+   * first index is a styles object for the SVG at the location, and the value
+   * at the second index is an optional function that renders additional
+   * components in the <g/> div.
    */
   styleLocation(location) {
     return [
       { fill: 'orange' },
-      () => <text>ciao</text>
     ]
   }
 
@@ -217,8 +219,8 @@ class Map extends React.Component {
 
     return (
       <div className={classes}>
-        <div id={this.props.mapId} />
-        {(this.map !== null) ? this.renderSVG() : ''}
+        <div id={this.props.ui.dom.map} />
+        {(this.map !== null) ? this.renderTiles() : ''}
         {(this.map !== null) ? this.renderMarkers() : ''}
         {(this.map !== null) && isShowingSites ? this.renderSites() : ''}
         {(this.map !== null) ? this.renderEvents() : ''}

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -52,7 +52,7 @@ class Map extends React.Component {
     const map =
       L.map(this.props.mapId)
         .setView(this.props.app.mapAnchor, 14)
-        .setMinZoom(10)
+        .setMinZoom(7)
         .setMaxZoom(18)
         .setMaxBounds([[180, -180], [-180, 180]])
 

--- a/src/components/MapEvents.jsx
+++ b/src/components/MapEvents.jsx
@@ -64,12 +64,12 @@ class MapEvents extends React.Component {
       <g
         className="location"
         transform={`translate(${x}, ${y})`}
+        onClick={() => this.props.onSelect(location.events)}
       >
         <circle
           className="location-event-marker"
           r={7}
           style={styles}
-          onClick={() => this.props.onSelect(events)}
         >
         </circle>
         {extraRender ? extraRender() : null}

--- a/src/components/MapEvents.jsx
+++ b/src/components/MapEvents.jsx
@@ -26,36 +26,6 @@ class MapEvents extends React.Component {
     return eventCount;
   }
 
-  renderCategory(events, category) {
-    let styles = ({
-      fill: this.props.getCategoryColor(category),
-      fillOpacity: 0.8
-    })
-
-    if (this.props.narrative) {
-      const { steps } = this.props.narrative
-      const onlyIfInNarrative = e => steps.map(s => s.id).includes(e.id)
-      const eventsInNarrative = events.filter(onlyIfInNarrative)
-
-      if (eventsInNarrative.length <= 0) {
-        styles = {
-          ...styles,
-          fillOpacity: 0.1
-        }
-      }
-    }
-
-    return (
-      <circle
-        className="location-event-marker"
-        r={7}
-        style={styles}
-        onClick={() => this.props.onSelect(events)}
-      >
-      </circle>
-    );
-  }
-
   renderLocation(location) {
     /**
     {
@@ -64,16 +34,19 @@ class MapEvents extends React.Component {
       latitude: '47.7',
       longitude: '32.2'
     }
-     */
+    */
     const { x, y } = this.projectPoint([location.latitude, location.longitude]);
-      // const eventsByCategory = this.getLocationEventsDistribution(location);
+    // const eventsByCategory = this.getLocationEventsDistribution(location);
 
     const locCategory = location.events.length > 0 ? location.events[0].category : 'default'
     const customStyles = this.props.styleLocation ? this.props.styleLocation(location) : null
+    const extraStyles = customStyles[0]
+    const extraRender = customStyles[1]
+
     const styles = ({
       fill: this.props.getCategoryColor(locCategory),
       fillOpacity: 1,
-      ...customStyles
+      ...customStyles[0]
     })
 
     // in narrative mode, only render events in narrative
@@ -99,6 +72,7 @@ class MapEvents extends React.Component {
           onClick={() => this.props.onSelect(events)}
         >
         </circle>
+        {extraRender ? extraRender() : null}
       </g>
     )
   }

--- a/src/components/MapEvents.jsx
+++ b/src/components/MapEvents.jsx
@@ -27,7 +27,7 @@ class MapEvents extends React.Component {
   }
 
   renderCategory(events, category) {
-    let styleProps = ({
+    let styles = ({
       fill: this.props.getCategoryColor(category),
       fillOpacity: 0.8
     })
@@ -38,8 +38,8 @@ class MapEvents extends React.Component {
       const eventsInNarrative = events.filter(onlyIfInNarrative)
 
       if (eventsInNarrative.length <= 0) {
-        styleProps = {
-          ...styleProps,
+        styles = {
+          ...styles,
           fillOpacity: 0.1
         }
       }
@@ -48,8 +48,8 @@ class MapEvents extends React.Component {
     return (
       <circle
         className="location-event-marker"
-        r={(events.length > 0) ? Math.sqrt(16 * events.length) + 3 : 0}
-        style={styleProps}
+        r={7}
+        style={styles}
         onClick={() => this.props.onSelect(events)}
       >
       </circle>
@@ -57,17 +57,48 @@ class MapEvents extends React.Component {
   }
 
   renderLocation(location) {
+    /**
+    {
+      events: [...],
+      label: 'Location name',
+      latitude: '47.7',
+      longitude: '32.2'
+    }
+     */
     const { x, y } = this.projectPoint([location.latitude, location.longitude]);
-    const eventsByCategory = this.getLocationEventsDistribution(location);
+      // const eventsByCategory = this.getLocationEventsDistribution(location);
+
+    const locCategory = location.events.length > 0 ? location.events[0].category : 'default'
+    const customStyles = this.props.styleLocation ? this.props.styleLocation(location) : null
+    const styles = ({
+      fill: this.props.getCategoryColor(locCategory),
+      fillOpacity: 1,
+      ...customStyles
+    })
+
+    // in narrative mode, only render events in narrative
+    if (this.props.narrative) {
+      const { steps } = this.props.narrative
+      const onlyIfInNarrative = e => steps.map(s => s.id).includes(e.id)
+      const eventsInNarrative = location.events.filter(onlyIfInNarrative)
+
+      if (eventsInNarrative.length <= 0) {
+        return null
+      }
+    }
 
     return (
       <g
         className="location"
         transform={`translate(${x}, ${y})`}
       >
-        {Object.keys(eventsByCategory).map(cat => {
-          return this.renderCategory(eventsByCategory[cat], cat)
-        })}
+        <circle
+          className="location-event-marker"
+          r={7}
+          style={styles}
+          onClick={() => this.props.onSelect(events)}
+        >
+        </circle>
       </g>
     )
   }

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -221,9 +221,7 @@ class Timeline extends React.Component {
    * components in the <g/> div.
    */
   styleDatetime(timestamp) {
-    return [
-      { fill: 'orange' },
-    ]
+    return []
   }
 
   render() {

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -212,9 +212,10 @@ class Timeline extends React.Component {
   }
 
   styleDatetime(timestamp) {
-    return {
-      fill: 'orange'
-    }
+    return [
+      { fill: 'orange' },
+      () => <text>ciao</text>
+    ]
   }
 
   render() {

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -19,6 +19,7 @@ class Timeline extends React.Component {
   constructor(props) {
     super(props);
     this.styleDatetime = this.styleDatetime.bind(this)
+    this.getDatetimeX = this.getDatetimeX.bind(this)
     this.svgRef = React.createRef()
     this.state = {
       isFolded: false,
@@ -80,22 +81,6 @@ class Timeline extends React.Component {
     if (prevState.timerange !== this.state.timerange) {
       this.setState({ scaleX: this.makeScaleX() });
     }
-  }
-
-  /**
-   * Get x position of eventPoint, considering the time scale
-   * @param {object} eventPoint: regular eventPoint data
-   */
-  getEventX(eventPoint) {
-    return this.state.scaleX(parseDate(eventPoint.timestamp));
-  }
-
-    /**
-   * Get y height of eventPoint, considering the ordinal Y scale
-   * @param {object} eventPoint: regular eventPoint data
-   */
-  getEventY(eventPoint) {
-    return this.state.scaleY(eventPoint.category);
   }
 
   /**
@@ -211,8 +196,16 @@ class Timeline extends React.Component {
     this.props.methods.onUpdateTimerange(this.state.timerange);
   }
 
+  getDatetimeX(dt) {
+    return this.state.scaleX(parseDate(dt.timestamp))
+  }
+
   /**
-   * Determines additional styles on the <circle> for each location.
+   * Determines additional styles on the <circle> for each timestamp. Note that
+   * timestamp visualisation functions slightly differently from locations, as
+   * a timestamp can be shown as multiple <circle>s (one per category of the
+   * events contained therein). Thus the function below has a category as an
+   * argumnent as well, in case timestamps ought to be styled per category.
    * A datetime consists of an array of events (see selectors). The function
    * also has full access to the domain and redux state to derive values if
    * necessary. The function should return an array, where the value at the
@@ -220,7 +213,7 @@ class Timeline extends React.Component {
    * at the second index is an optional function that renders additional
    * components in the <g/> div.
    */
-  styleDatetime(timestamp) {
+  styleDatetime(timestamp, category) {
     return []
   }
 
@@ -285,8 +278,8 @@ class Timeline extends React.Component {
                 datetimes={this.props.domain.datetimes}
                 styleDatetime={this.styleDatetime}
                 narrative={this.props.app.narrative}
-                getDatetimeX={(e) => this.getEventX(e)}
-                getDatetimeY={(e) => this.getEventY(e)}
+                getDatetimeX={this.getDatetimeX}
+                getCategoryY={this.state.scaleY}
                 getCategoryColor={this.props.methods.getCategoryColor}
                 transitionDuration={this.state.transitionDuration}
                 onSelect={this.props.methods.onSelect}

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -18,6 +18,7 @@ import TimelineCategories from './TimelineCategories.jsx';
 class Timeline extends React.Component {
   constructor(props) {
     super(props);
+    this.styleDatetime = this.styleDatetime.bind(this)
     this.svgRef = React.createRef()
     this.state = {
       isFolded: false,
@@ -210,67 +211,18 @@ class Timeline extends React.Component {
     this.props.methods.onUpdateTimerange(this.state.timerange);
   }
 
-  renderSVG() {
-    const dims = this.state.dims;
-
-    return (
-      <svg
-        ref={this.svgRef}
-        width={dims.width}
-        height={dims.height}
-      >
-        <TimelineClip
-          dims={dims}
-        />
-        <TimelineAxis
-          dims={dims}
-          timerange={this.props.app.timerange}
-          transitionDuration={this.state.transitionDuration}
-          scaleX={this.state.scaleX}
-        />
-        <TimelineCategories
-          dims={dims}
-          onDragStart={() => { this.onDragStart() }}
-          onDrag={() => { this.onDrag() }}
-          onDragEnd={() => { this.onDragEnd() }}
-          categories={this.props.domain.categories}
-        />
-        <TimelineHandles
-          dims={dims}
-          onMoveTime={(dir) => { this.onMoveTime(dir) }}
-        />
-        <TimelineZoomControls
-          zoomLevels={this.props.app.zoomLevels}
-          dims={dims}
-          onApplyZoom={(zoom) => { this.onApplyZoom(zoom); }}
-        />
-        <TimelineLabels
-          dims={dims}
-          timelabels={this.state.timerange}
-        />
-        <TimelineMarkers
-          selected={this.props.app.selected}
-          getEventX={(e) => this.getEventX(e)}
-          getEventY={(e) => this.getEventY(e)}
-          transitionDuration={this.state.transitionDuration}
-        />
-        <TimelineEvents
-          events={this.props.domain.events}
-          narrative={this.props.app.narrative}
-          getEventX={(e) => this.getEventX(e)}
-          getEventY={(e) => this.getEventY(e)}
-          getCategoryColor={this.props.methods.getCategoryColor}
-          transitionDuration={this.state.transitionDuration}
-          onSelect={this.props.methods.onSelect}
-        />
-      </svg>
-    )
+  styleDatetime(timestamp) {
+    return {
+      fill: 'orange'
+    }
   }
 
   render() {
     const { isNarrative, app, ui } = this.props
     let classes = `timeline-wrapper ${(this.state.isFolded) ? ' folded' : ''}`;
     classes += (app.narrative !== null) ? ' narrative-mode' : '';
+    const dims = this.state.dims;
+
     return (
       <div className={classes}>
         <TimelineHeader
@@ -282,7 +234,57 @@ class Timeline extends React.Component {
         />
         <div className="timeline-content">
           <div id={this.props.ui.dom.timeline} className="timeline">
-            {this.renderSVG()}
+            <svg
+              ref={this.svgRef}
+              width={dims.width}
+              height={dims.height}
+            >
+              <TimelineClip
+                dims={dims}
+              />
+              <TimelineAxis
+                dims={dims}
+                timerange={this.props.app.timerange}
+                transitionDuration={this.state.transitionDuration}
+                scaleX={this.state.scaleX}
+              />
+              <TimelineCategories
+                dims={dims}
+                onDragStart={() => { this.onDragStart() }}
+                onDrag={() => { this.onDrag() }}
+                onDragEnd={() => { this.onDragEnd() }}
+                categories={this.props.domain.categories}
+              />
+              <TimelineHandles
+                dims={dims}
+                onMoveTime={(dir) => { this.onMoveTime(dir) }}
+              />
+              <TimelineZoomControls
+                zoomLevels={this.props.app.zoomLevels}
+                dims={dims}
+                onApplyZoom={(zoom) => { this.onApplyZoom(zoom); }}
+              />
+              <TimelineLabels
+                dims={dims}
+                timelabels={this.state.timerange}
+              />
+              <TimelineMarkers
+                selected={this.props.app.selected}
+                getEventX={(e) => this.getEventX(e)}
+                getEventY={(e) => this.getEventY(e)}
+                transitionDuration={this.state.transitionDuration}
+              />
+              <TimelineEvents
+                datetimes={this.props.domain.datetimes}
+                styleDatetime={this.styleDatetime}
+                narrative={this.props.app.narrative}
+                getDatetimeX={(e) => this.getEventX(e)}
+                getDatetimeY={(e) => this.getEventY(e)}
+                getCategoryColor={this.props.methods.getCategoryColor}
+                transitionDuration={this.state.transitionDuration}
+                onSelect={this.props.methods.onSelect}
+              />
+            </svg>
           </div>
         </div>
       </div>
@@ -294,7 +296,7 @@ function mapStateToProps(state) {
   return {
     isNarrative: !!state.app.narrative,
     domain: {
-      events: state.domain.events,
+      datetimes: selectors.selectDatetimes(state),
       categories: selectors.selectCategories(state),
       narratives: state.domain.narratives
     },

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -211,10 +211,18 @@ class Timeline extends React.Component {
     this.props.methods.onUpdateTimerange(this.state.timerange);
   }
 
+  /**
+   * Determines additional styles on the <circle> for each location.
+   * A datetime consists of an array of events (see selectors). The function
+   * also has full access to the domain and redux state to derive values if
+   * necessary. The function should return an array, where the value at the
+   * first index is a styles object for the SVG at the location, and the value
+   * at the second index is an optional function that renders additional
+   * components in the <g/> div.
+   */
   styleDatetime(timestamp) {
     return [
       { fill: 'orange' },
-      () => <text>ciao</text>
     ]
   }
 

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -271,15 +271,15 @@ class Timeline extends React.Component {
               <TimelineMarkers
                 selected={this.props.app.selected}
                 getEventX={this.getDatetimeX}
-                getCategoryY={this.getCategoryY}
+                getCategoryY={this.state.scaleY}
                 transitionDuration={this.state.transitionDuration}
               />
               <TimelineEvents
                 datetimes={this.props.domain.datetimes}
                 styleDatetime={this.styleDatetime}
                 narrative={this.props.app.narrative}
-                getEventX={this.getEventX}
-                getCategoryY={this.getCategoryY}
+                getDatetimeX={this.getDatetimeX}
+                getCategoryY={this.state.scaleY}
                 getCategoryColor={this.props.methods.getCategoryColor}
                 transitionDuration={this.state.transitionDuration}
                 onSelect={this.props.methods.onSelect}

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -270,16 +270,16 @@ class Timeline extends React.Component {
               />
               <TimelineMarkers
                 selected={this.props.app.selected}
-                getEventX={(e) => this.getEventX(e)}
-                getEventY={(e) => this.getEventY(e)}
+                getEventX={this.getDatetimeX}
+                getCategoryY={this.getCategoryY}
                 transitionDuration={this.state.transitionDuration}
               />
               <TimelineEvents
                 datetimes={this.props.domain.datetimes}
                 styleDatetime={this.styleDatetime}
                 narrative={this.props.app.narrative}
-                getDatetimeX={this.getDatetimeX}
-                getCategoryY={this.state.scaleY}
+                getEventX={this.getEventX}
+                getCategoryY={this.getCategoryY}
                 getCategoryColor={this.props.methods.getCategoryColor}
                 transitionDuration={this.state.transitionDuration}
                 onSelect={this.props.methods.onSelect}

--- a/src/components/presentational/DatetimeDot.js
+++ b/src/components/presentational/DatetimeDot.js
@@ -1,0 +1,27 @@
+import React from 'react'
+
+export default ({
+  category,
+  events,
+  x,
+  y,
+  styleProps,
+  extraRender
+}) => (
+  <g
+    className='datetime'
+    transform={`translate(${x}, ${y})`}
+    onClick={() => onSelect(datetime.events)}
+  >
+    <circle
+      className="event"
+      cx={0}
+      cy={0}
+      style={styleProps}
+      r={5}
+    >
+    </circle>
+    { extraRender ? extraRender() : null }
+  </g>
+)
+

--- a/src/components/presentational/DatetimeDot.js
+++ b/src/components/presentational/DatetimeDot.js
@@ -11,7 +11,7 @@ export default ({
   <g
     className='datetime'
     transform={`translate(${x}, ${y})`}
-    onClick={() => onSelect(datetime.events)}
+    onClick={() => onSelect(events)}
   >
     <circle
       className="event"

--- a/src/components/presentational/DatetimeDot.js
+++ b/src/components/presentational/DatetimeDot.js
@@ -5,6 +5,7 @@ export default ({
   events,
   x,
   y,
+  onSelect,
   styleProps,
   extraRender
 }) => (

--- a/src/components/presentational/TimelineEvents.js
+++ b/src/components/presentational/TimelineEvents.js
@@ -58,6 +58,7 @@ const TimelineEvents = ({
 
       return (
         <DatetimeDot
+          onSelect={onSelect}
           category={dot.category}
           events={dot.events}
           x={getDatetimeX(datetime)}

--- a/src/components/presentational/TimelineEvents.js
+++ b/src/components/presentational/TimelineEvents.js
@@ -1,21 +1,30 @@
 import React from 'react';
 
-const TimelineEvents = ({ events, narrative, getEventX, getEventY,
-  getCategoryColor, onSelect, transitionDuration }) => {
-
+const TimelineEvents = ({
+  datetimes,
+  narrative,
+  getDatetimeX,
+  getDatetimeY,
+  getCategoryColor,
+  onSelect,
+  transitionDuration,
+  styleDatetime
+}) => {
   function getAllEventsAtOnce(eventPoint) {
-    const timestamp = eventPoint.timestamp;
+    const datetime = eventPoint.datetime;
     const category = eventPoint.category;
     return events
-      .filter(event => (event.timestamp === timestamp && category === event.category))
+      .filter(event => (event.datetime === datetime && category === event.category))
   }
 
-  function renderEvent(event) {
-    let styleProps = ({
-      fill: getCategoryColor(event.category),
-      fillOpacity: 0.8,
-      transform: `translate(${getEventX(event)}px, ${getEventY(event)}px)`,
-      transition: `transform ${transitionDuration / 1000}s ease`
+  function renderDatetime(datetime) {
+    const customStyles = styleDatetime ? styleDatetime(datetime) : null
+    const styleProps = ({
+      fill: getCategoryColor(datetime.events[0].category),
+      fillOpacity: 1,
+      transform: `translate(${getDatetimeX(datetime)}px, ${getDatetimeY(datetime)}px)`,
+      transition: `transform ${transitionDuration / 1000}s ease`,
+      ...customStyles
     });
 
     if (narrative) {
@@ -23,10 +32,7 @@ const TimelineEvents = ({ events, narrative, getEventX, getEventY,
       const isInNarrative = steps.map(s => s.id).includes(event.id)
 
       if (!isInNarrative) {
-        styleProps = {
-          ...styleProps,
-          fillOpacity: 0.1
-        }
+        return null
       }
     }
 
@@ -36,7 +42,7 @@ const TimelineEvents = ({ events, narrative, getEventX, getEventY,
         cx={0}
         cy={0}
         style={styleProps}
-        r={5}        
+        r={5}
         onClick={() => {onSelect(getAllEventsAtOnce(event))}}
       >
       </circle>
@@ -47,7 +53,7 @@ const TimelineEvents = ({ events, narrative, getEventX, getEventY,
     <g
       clipPath={"url(#clip)"}
     >
-      {events.map(event => renderEvent(event))}
+      {datetimes.map(datetime => renderDatetime(datetime))}
     </g>
   );
 }

--- a/src/components/presentational/TimelineEvents.js
+++ b/src/components/presentational/TimelineEvents.js
@@ -35,6 +35,7 @@ const TimelineEvents = ({
       <g
         className='datetime'
         transform={`translate(${getDatetimeX(datetime)}, ${getDatetimeY(datetime)})`}
+        onClick={() => onSelect(datetime.events)}
       >
         <circle
           className="event"
@@ -42,7 +43,6 @@ const TimelineEvents = ({
           cy={0}
           style={styleProps}
           r={5}
-          onClick={() => onSelect(datetime.events)}
         >
         </circle>
         { extraRender ? extraRender() : null }

--- a/src/components/presentational/TimelineEvents.js
+++ b/src/components/presentational/TimelineEvents.js
@@ -12,12 +12,14 @@ const TimelineEvents = ({
 }) => {
   function renderDatetime(datetime) {
     const customStyles = styleDatetime ? styleDatetime(datetime) : null
+    const extraStyles = customStyles[0]
+    const extraRender = customStyles[1]
+
     const styleProps = ({
       fill: getCategoryColor(datetime.events[0].category),
       fillOpacity: 1,
-      transform: `translate(${getDatetimeX(datetime)}px, ${getDatetimeY(datetime)}px)`,
       transition: `transform ${transitionDuration / 1000}s ease`,
-      ...customStyles
+      ...extraStyles
     });
 
     if (narrative) {
@@ -30,15 +32,21 @@ const TimelineEvents = ({
     }
 
     return (
-      <circle
-        className="event"
-        cx={0}
-        cy={0}
-        style={styleProps}
-        r={5}
-        onClick={() => onSelect(datetime.events)}
+      <g
+        className='datetime'
+        transform={`translate(${getDatetimeX(datetime)}, ${getDatetimeY(datetime)})`}
       >
-      </circle>
+        <circle
+          className="event"
+          cx={0}
+          cy={0}
+          style={styleProps}
+          r={5}
+          onClick={() => onSelect(datetime.events)}
+        >
+        </circle>
+        { extraRender ? extraRender() : null }
+      </g>
     )
   }
 

--- a/src/components/presentational/TimelineEvents.js
+++ b/src/components/presentational/TimelineEvents.js
@@ -10,13 +10,6 @@ const TimelineEvents = ({
   transitionDuration,
   styleDatetime
 }) => {
-  function getAllEventsAtOnce(eventPoint) {
-    const datetime = eventPoint.datetime;
-    const category = eventPoint.category;
-    return events
-      .filter(event => (event.datetime === datetime && category === event.category))
-  }
-
   function renderDatetime(datetime) {
     const customStyles = styleDatetime ? styleDatetime(datetime) : null
     const styleProps = ({
@@ -43,7 +36,7 @@ const TimelineEvents = ({
         cy={0}
         style={styleProps}
         r={5}
-        onClick={() => {onSelect(getAllEventsAtOnce(event))}}
+        onClick={() => onSelect(datetime.events)}
       >
       </circle>
     )

--- a/src/components/presentational/TimelineMarkers.js
+++ b/src/components/presentational/TimelineMarkers.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const TimelineMarkers = ({ getEventX, getEventY, transitionDuration, selected }) => {
+const TimelineMarkers = ({ getEventX, getCategoryY, transitionDuration, selected }) => {
   function renderMarker(event) {
     return (
       <circle
@@ -8,11 +8,11 @@ const TimelineMarkers = ({ getEventX, getEventY, transitionDuration, selected })
         cx={0}
         cy={0}
         style={{
-          'transform': `translate(${getEventX(event)}px, ${getEventY(event)}px)`,
+          'transform': `translate(${getEventX(event)}px, ${getCategoryY(event.category)}px)`,
           '-webkit-transition': `transform ${transitionDuration / 1000}s ease`,
           '-moz-transition': 'none',
           'opacity': 0.9
-        }}        
+        }}
         r="10"
       >
       </circle>

--- a/src/scss/map.scss
+++ b/src/scss/map.scss
@@ -165,19 +165,23 @@
 * Elements
 */
 
+.location {
+  cursor: pointer;
+}
+
 .location-event-marker {
   fill: $event_default;
   stroke-width: 0;
-  cursor: pointer;
-
-  &:hover {
-    fill-opacity: 1;
-  }
 }
 
 .path-polyline {
   stroke: $darkgrey;
   stroke-width: 2px;
+}
+
+.location-count {
+  z-index: 100;
+  fill: #a4a4a4;
 }
 
 

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -23,7 +23,6 @@ export const getTagsFilter = state => state.app.filters.tags
 export const getTimeRange = state => state.app.filters.timerange
 
 
-
 /**
 * Some handy helpers
 */
@@ -148,9 +147,15 @@ export const selectActiveNarrative = createSelector(
     ? { ...narrative, current }
     : null
 )
+
 /**
- * Of all the filtered events, group them by location and return a list of
- * locations with at least one event in it, based on the time range and tags
+ * Group events by location. Each location is an object:
+  {
+    events: [...],
+    label: 'Location name',
+    latitude: '47.7',
+    longitude: '32.2'
+  }
  */
 export const selectLocations = createSelector(
   [selectEvents],
@@ -171,11 +176,39 @@ export const selectLocations = createSelector(
         }
       }
     })
-
     return Object.values(selectedLocations)
   }
 )
 
+/**
+ * Group events by 'datetime'. Each datetime is  an object:
+  {
+    timestamp: '',
+    date: '8/23/2016',
+    time: '12:00',
+    events: [...]
+  }
+ */
+export const selectDatetimes = createSelector(
+  [selectEvents],
+  events => {
+    const datetimes = {}
+    events.forEach(event => {
+      const { timestamp } = event
+      if (datetimes.hasOwnProperty(timestamp)) {
+        datetimes[timestamp].events.push(event)
+      } else {
+        datetimes[timestamp] = {
+          timestamp: event.timestamp,
+          date: event.date,
+          time: event.time,
+          events: [event]
+        }
+      }
+    })
+    return Object.values(datetimes)
+  }
+)
 
 
 /**

--- a/src/store/initial.js
+++ b/src/store/initial.js
@@ -113,7 +113,6 @@ const initial = {
         beta: '#ff0000',
         other: '#f3de2c'
       },
-
       narratives: {
         default: {
           opacity: 0.9,


### PR DESCRIPTION
This PR creates two functions `styleLocation` and `styleDatetime` in `Map` and `Timeline` respectively that allow additional styles to be composed for the SVGs that are rendered in those components. 

Locations and datetimes are intermediate representations by which events become visual in the component. (Locations in `Map` existed before this PR, datetimes in `Timeline` were added.) A datetime is the vehicle that ferries one or more events (all those that occur at the datetime) from the redux domain to a visual representation on the timeline. Each datetime is represented as a single circle on the timeline by default. Locations in `Map` work the same way.

The functions `styleLocation` and `styleDatetime` are props passed to the `MapEvents` and `TimelineEvents` components that allow custom style props and render items to be added to the SVG location/datetime. This is useful, as it means that custom representations of events in timeline/map can easily be written as a function of the domain, or any other part of the redux state.

By default, all locations in `Map` are now the same size. If there is more than one event contained by a location, a `<text>` element with the appropriate count is added to the rendered representation in `Map`.

closes #71 