### PR TITLE
First zoom narrative

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -35,17 +35,19 @@ class Map extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (hash(nextProps.app.selected) !== hash(this.props.app.selected)) {
-
-      // Fly to first  of events selected
-      const eventPoint = (nextProps.app.selected.length > 0) ? nextProps.app.selected[0] : null;
-
-      if (eventPoint !== null && eventPoint.latitude && eventPoint.longitude) {
-        this.map.setView([eventPoint.latitude, eventPoint.longitude]);
-      }
-    }
-    if (hash(nextProps.app.mapBounds) !== hash(this.props.app.mapBounds) && nextProps.app.mapBounds !== null) {
-      this.map.fitBounds(nextProps.app.mapBounds);
+    // Set appropriate zoom for narrative 
+    if (hash(nextProps.app.mapBounds) !== hash(this.props.app.mapBounds)
+      && nextProps.app.mapBounds !== null) {
+        this.map.fitBounds(nextProps.app.mapBounds);
+    } else {
+      if (hash(nextProps.app.selected) !== hash(this.props.app.selected)) {
+        // Fly to first  of events selected
+        const eventPoint = (nextProps.app.selected.length > 0) ? nextProps.app.selected[0] : null;
+  
+        if (eventPoint !== null && eventPoint.latitude && eventPoint.longitude) {
+          this.map.setView([eventPoint.latitude, eventPoint.longitude]);
+        }
+      }  
     }
   }  
 

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -251,7 +251,7 @@ function mapStateToProps(state) {
       selected: state.app.selected,
       highlighted: state.app.highlighted,
       mapAnchor: state.app.mapAnchor,
-      mapBounds: state.app.filters.mapBounds
+      mapBounds: state.app.filters.mapBounds,
       narrative: state.app.narrative,
       flags: {
         isShowingSites: state.app.flags.isShowingSites

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -44,7 +44,10 @@ class Map extends React.Component {
         this.map.setView([eventPoint.latitude, eventPoint.longitude]);
       }
     }
-  }
+    if (hash(nextProps.app.mapBounds) !== hash(this.props.app.mapBounds) && nextProps.app.mapBounds !== null) {
+      this.map.fitBounds(nextProps.app.mapBounds);
+    }
+  }  
 
   initializeMap() {
     /**
@@ -246,6 +249,7 @@ function mapStateToProps(state) {
       selected: state.app.selected,
       highlighted: state.app.highlighted,
       mapAnchor: state.app.mapAnchor,
+      mapBounds: state.app.filters.mapBounds
       narrative: state.app.narrative,
       flags: {
         isShowingSites: state.app.flags.isShowingSites

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -71,7 +71,7 @@ class Timeline extends React.Component {
     let element = document.querySelector('.timeline-wrapper');
     element.addEventListener("transitionend", (event) => {
       this.computeDims();
-    }, false);
+    }, { once: true });
 
   }
 

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -68,6 +68,11 @@ class Timeline extends React.Component {
 
   addEventListeners() {
     window.addEventListener('resize', () => { this.computeDims(); });
+    let element = document.querySelector('.timeline-wrapper');
+    element.addEventListener("transitionend", (event) => {
+      this.computeDims();
+    }, false);
+
   }
 
   makeScaleX() {
@@ -109,7 +114,8 @@ class Timeline extends React.Component {
       const boundingClient = document.querySelector(`#${dom}`).getBoundingClientRect();
 
       this.setState({
-        dims: Object.assign({}, this.state.dims, { width: boundingClient.width })
+          dims: Object.assign({}, this.state.dims, { width: boundingClient.width })
+        }, () => { this.setState({ scaleX: this.makeScaleX() })
       });
     }
   }

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -60,8 +60,8 @@ class Timeline extends React.Component {
     }
 
     if (hash(nextProps.app.selected) !== hash(this.props.app.selected)) {
-      if (nextProps.app.selected !== null) {
-       this.onCenterTime(parseDate(nextProps.app.selected[0].timestamp));
+      if (!!nextProps.app.selected && nextProps.app.selected.length > 0) {
+        this.onCenterTime(parseDate(nextProps.app.selected[0].timestamp));
       }
     }
   }

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -58,6 +58,12 @@ class Timeline extends React.Component {
         scaleY: this.makeScaleY(nextProps.domain.categories)
       });
     }
+
+    if (hash(nextProps.app.selected) !== hash(this.props.app.selected)) {
+      if (nextProps.app.selected !== null) {
+       this.onCenterTime(parseDate(nextProps.app.selected[0].timestamp));
+      }
+    }
   }
 
   addEventListeners() {
@@ -130,6 +136,17 @@ class Timeline extends React.Component {
     this.setState({ timerange: [domain0, domainF] }, () => {
       this.props.methods.onUpdateTimerange(this.state.timerange);
     });
+  }
+
+  onCenterTime(newCentralTime) {
+    const extent = this.getTimeScaleExtent();
+
+    const domain0 = d3.timeMinute.offset(newCentralTime, -extent/2);
+    const domainF = d3.timeMinute.offset(newCentralTime, +extent/2);
+
+    this.setState({ timerange: [domain0, domainF] }, () => {
+      this.props.methods.onUpdateTimerange(this.state.timerange);
+    });    
   }
 
   /**

--- a/src/components/presentational/TimelineEvents.js
+++ b/src/components/presentational/TimelineEvents.js
@@ -35,7 +35,15 @@ const TimelineEvents = ({
   function renderDatetime(datetime) {
     if (narrative) {
       const { steps } = narrative
-      const isInNarrative = steps.map(s => s.id).includes(event.id)
+      // check all events in the datetime before rendering in narrative
+      let isInNarrative = false
+      for (let i = 0; i < datetime.events.length; i++) {
+        const event = datetime.events[i]
+        if (steps.map(s => s.id).includes(event.id)) {
+          isInNarrative = true
+          break;
+        }
+      }
 
       if (!isInNarrative) {
         return null

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -36,11 +36,29 @@ function updateSelected(appState, action) {
 }
 
 function updateNarrative(appState, action) {
+  let minTime = appState.filters.timerange[0];
+  let maxTime = appState.filters.timerange[1];
+
+  if (!!action.narrative) {
+    minTime = parseDate('2100-01-01T00:00:00');
+    maxTime = parseDate('1900-01-01T00:00:00');
+
+    action.narrative.steps.forEach(step => {
+      const stepTime = parseDate(step.timestamp);
+      if (stepTime < minTime) minTime = stepTime;
+      if (stepTime > maxTime) maxTime = stepTime;
+    });
+  }
+
   return {
     ...appState,
     narrative: action.narrative,
     narrativeState: {
       current: !!action.narrative ? 0 : null
+    },
+    filters: {
+      ...appState.filters,
+      timerange: [minTime, maxTime]
     }
   }
 }

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -57,6 +57,9 @@ function updateNarrative(appState, action) {
       if (+step.latitude < cornerBound0[0]) cornerBound0[0] = +step.latitude;
       if (+step.latitude > cornerBound1[0]) cornerBound1[0] = +step.latitude;
     });
+
+    minTime = new Date(minTime.getTime() - Math.abs((maxTime - minTime) / 10));
+    maxTime = new Date(maxTime.getTime() + Math.abs((maxTime - minTime) / 10));
   }
 
   return {

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -39,6 +39,10 @@ function updateNarrative(appState, action) {
   let minTime = appState.filters.timerange[0];
   let maxTime = appState.filters.timerange[1];
 
+  let cornerBound0 = [180, 180];
+  let cornerBound1 = [-180, -180];
+
+  // Compute narrative time range and map bounds
   if (!!action.narrative) {
     minTime = parseDate('2100-01-01T00:00:00');
     maxTime = parseDate('1900-01-01T00:00:00');
@@ -47,6 +51,11 @@ function updateNarrative(appState, action) {
       const stepTime = parseDate(step.timestamp);
       if (stepTime < minTime) minTime = stepTime;
       if (stepTime > maxTime) maxTime = stepTime;
+
+      if (+step.longitude < cornerBound0[1]) cornerBound0[1] = +step.longitude;
+      if (+step.longitude > cornerBound1[1]) cornerBound1[1] = +step.longitude;
+      if (+step.latitude < cornerBound0[0]) cornerBound0[0] = +step.latitude;
+      if (+step.latitude > cornerBound1[0]) cornerBound1[0] = +step.latitude;
     });
   }
 
@@ -58,7 +67,8 @@ function updateNarrative(appState, action) {
     },
     filters: {
       ...appState.filters,
-      timerange: [minTime, maxTime]
+      timerange: [minTime, maxTime],
+      mapBounds: [cornerBound0, cornerBound1]
     }
   }
 }

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -52,10 +52,12 @@ function updateNarrative(appState, action) {
       if (stepTime < minTime) minTime = stepTime;
       if (stepTime > maxTime) maxTime = stepTime;
 
-      if (+step.longitude < cornerBound0[1]) cornerBound0[1] = +step.longitude;
-      if (+step.longitude > cornerBound1[1]) cornerBound1[1] = +step.longitude;
-      if (+step.latitude < cornerBound0[0]) cornerBound0[0] = +step.latitude;
-      if (+step.latitude > cornerBound1[0]) cornerBound1[0] = +step.latitude;
+      if (!!step.longitude && !!step.latitude) {
+        if (+step.longitude < cornerBound0[1]) cornerBound0[1] = +step.longitude;
+        if (+step.longitude > cornerBound1[1]) cornerBound1[1] = +step.longitude;
+        if (+step.latitude < cornerBound0[0]) cornerBound0[0] = +step.latitude;
+        if (+step.latitude > cornerBound1[0]) cornerBound1[0] = +step.latitude;  
+      }
     });
 
     minTime = new Date(minTime.getTime() - Math.abs((maxTime - minTime) / 10));
@@ -71,7 +73,7 @@ function updateNarrative(appState, action) {
     filters: {
       ...appState.filters,
       timerange: [minTime, maxTime],
-      mapBounds: [cornerBound0, cornerBound1]
+      mapBounds: (action.narrative) ? [cornerBound0, cornerBound1] : null
     }
   }
 }

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -47,6 +47,7 @@ function updateNarrative(appState, action) {
     minTime = parseDate('2100-01-01T00:00:00');
     maxTime = parseDate('1900-01-01T00:00:00');
 
+    // Find max and mins coordinates of narrative events
     action.narrative.steps.forEach(step => {
       const stepTime = parseDate(step.timestamp);
       if (stepTime < minTime) minTime = stepTime;
@@ -59,7 +60,23 @@ function updateNarrative(appState, action) {
         if (+step.latitude > cornerBound1[0]) cornerBound1[0] = +step.latitude;  
       }
     });
+    // Adjust bounds to center around first event, while keeping visible all others
+    // Takes first event, finds max ditance with first attempt bounds, and use this max distance
+    // on the other side, both in latitude and longitude
+    const first = action.narrative.steps[0];
+    if (!!first.longitude && !!first.latitude) {
+      const firstToLong0 = Math.abs(+first.longitude - cornerBound0[1]);
+      const firstToLong1 = Math.abs(+first.longitude - cornerBound1[1]);
+      const firstToLat0 = Math.abs(+first.latitude - cornerBound0[0]);
+      const firstToLat1 = Math.abs(+first.latitude - cornerBound1[0]);
 
+      if (firstToLong0 > firstToLong1) cornerBound1[1] = +first.longitude + firstToLong0;
+      if (firstToLong0 < firstToLong1) cornerBound0[1] = +first.longitude - firstToLong1;
+      if (firstToLat0 > firstToLat1) cornerBound1[0] = +first.latitude + firstToLat0;
+      if (firstToLat0 < firstToLat1) cornerBound0[0] = +first.latitude - firstToLat1;
+    }
+    
+    // Add some buffer on both sides of the time extent
     minTime = new Date(minTime.getTime() - Math.abs((maxTime - minTime) / 10));
     maxTime = new Date(maxTime.getTime() + Math.abs((maxTime - minTime) / 10));
   }

--- a/src/store/initial.js
+++ b/src/store/initial.js
@@ -41,6 +41,7 @@ const initial = {
         d3.timeParse("%Y-%m-%dT%H:%M:%S")("2013-02-23T12:00:00"),
         d3.timeParse("%Y-%m-%dT%H:%M:%S")("2016-02-23T12:00:00")
       ],
+      mapBounds: null,
       tags: [],
       categories: [],
       views: {


### PR DESCRIPTION
This PR implements a series of zooming features to improve the experience.
When the user enters narrative mode by selecting a narrative in the toolbar:
- The timeline zooms to a scope that spans all of the events in the narrative, by zooming in or out accordingly.
- The map zooms in or out to a level where all events in the narratives are visible.
This closes #73.

Additionally, when the user selects an event, the timeline automatically now centers itself on the selected event, without changing the zoom. this closes #72.