### PR TITLE
dockerfile to containerise build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules/
+build/
+example.config.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM mhart/alpine-node:10.11
+
+LABEL authors="Lachlan Kermode <lk@forensic-architecture.org>"
+
+# Install app dependencies
+COPY package.json /www/package.json
+RUN cd /www; yarn
+
+# Copy app source
+COPY . /www
+WORKDIR /www
+RUN yarn build
+
+# files available to copy at /www/build


### PR DESCRIPTION
Containerise the build by adding a Docker image. Files can then be copied out of a created container from `/www/build` using `docker cp`.