### PR TITLE
Topic/categories as tags

### DIFF
--- a/example.config.js
+++ b/example.config.js
@@ -14,7 +14,8 @@ module.exports = {
     USE_TAGS: false,
     USE_SEARCH: false,
     USE_SITES: true,
-    USE_SOURCES: true
+    USE_SOURCES: true,
+    CATEGORIES_AS_TAGS: true
   }
 }
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -10,7 +10,7 @@ function urlFromEnv(ext) {
 // TODO: relegate these URLs entirely to environment variables
 const EVENT_DATA_URL = urlFromEnv('EVENT_EXT');
 const CATEGORY_URL = urlFromEnv('CATEGORY_EXT');
-const TAG_URL = urlFromEnv('TAGS_EXT');
+const TAGS_URL = urlFromEnv('TAGS_EXT');
 const SOURCES_URL = urlFromEnv('SOURCES_EXT');
 const NARRATIVE_URL = urlFromEnv('NARRATIVE_EXT');
 const SITES_URL = urlFromEnv('SITES_EXT');
@@ -23,18 +23,6 @@ function _debugger(value) {
   return {
     type: DEBUG_GER,
     value
-  }
-}
-
-/*
-* Create an error notification object
-* Types: ['error', 'warning', 'good', 'neural']
-*/
-function makeError (type, id, message) {
-  return {
-    type: 'error',
-    id,
-    message: `${type} ${id}: ${message}`
   }
 }
 
@@ -76,16 +64,38 @@ export function fetchDomain () {
 
     let tagsPromise = Promise.resolve([])
     if (process.env.features.USE_TAGS) {
-      tagsPromise = fetch(TAG_URL)
-        .then(response => response.json())
-        .catch(handleError('tags'))
+      if (!TAGS_URL) {
+        notifications.push({
+          message: 'USE_TAGS is true, but you have not provided a TAGS_URL',
+          type: 'error'
+        })
+        tagsPromise = Promise.resolve({})
+      } else {
+        tagsPromise = fetch(TAGS_URL)
+          .then(response => {
+            console.log(response)
+            return response.json()
+          })
+          .catch(err => {
+            console.log(err)
+            return handleError('tags')
+          })
+      }
     }
 
     let sourcesPromise = Promise.resolve([])
     if (process.env.features.USE_SOURCES) {
-      sourcesPromise = fetch(SOURCES_URL)
-        .then(response => response.json())
-        .catch(handleError('sources'))
+      if (!SOURCES_URL) {
+        notifications.push({
+          message: 'USE_SOURCES is true, but you have not provided a SOURCES_URL',
+          type: 'error'
+        })
+        tagsPromise = Prommise.resolve([])
+      } else {
+        sourcesPromise = fetch(SOURCES_URL)
+          .then(response => response.json())
+          .catch(handleError('sources'))
+      }
     }
 
     return Promise.all([

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -189,11 +189,19 @@ export function updateDistrict(district) {
   }
 }
 
-export const UPDATE_TAGFILTERS = 'UPDATE_TIMEFILTERS'
+export const UPDATE_TAGFILTERS = 'UPDATE_TAGFILTERS'
 export function updateTagFilters(tag) {
   return {
     type: UPDATE_TAGFILTERS,
     tag
+  }
+}
+
+export const UPDATE_CATEGORYFILTERS = 'UPDATE_CATEGORYFILTERS'
+export function updateCategoryFilters(category) {
+  return {
+    type: UPDATE_CATEGORYFILTERS,
+    category
   }
 }
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,13 +1,5 @@
-// TODO: move to util lib
-function urlFromEnv(ext) {
-  if (process.env[ext]) {
-    return `${process.env.SERVER_ROOT}${process.env[ext]}`
-  } else {
-    return null
-  }
-}
+import { urlFromEnv } from '../js/utilities'
 
-// TODO: relegate these URLs entirely to environment variables
 const EVENT_DATA_URL = urlFromEnv('EVENT_EXT');
 const CATEGORY_URL = urlFromEnv('CATEGORY_EXT');
 const TAGS_URL = urlFromEnv('TAGS_EXT');
@@ -15,16 +7,6 @@ const SOURCES_URL = urlFromEnv('SOURCES_EXT');
 const NARRATIVE_URL = urlFromEnv('NARRATIVE_EXT');
 const SITES_URL = urlFromEnv('SITES_EXT');
 const eventUrlMap = (event) => `${process.env.SERVER_ROOT}${process.env.EVENT_DESC_ROOT}/${(event.id) ? event.id : event}`;
-
-
-const DEBUG_GER = 'DEBUG_GER'
-function _debugger(value) {
-  console.log(value)
-  return {
-    type: DEBUG_GER,
-    value
-  }
-}
 
 const domainMsg = (domainType) => `Something went wrong fetching ${domainType}. Check the URL or try disabling them in the config file.`
 
@@ -66,13 +48,10 @@ export function fetchDomain () {
     let tagsPromise = Promise.resolve([])
     if (process.env.features.USE_TAGS) {
       if (!TAGS_URL) {
-        tagsPromise = Promise.resolve(handleError('USE_TAGS is true, but you have not provided a TAGS_URL'))
+        tagsPromise = Promise.resolve(handleError('USE_TAGS is true, but you have not provided a TAGS_EXT'))
       } else {
         tagsPromise = fetch(TAGS_URL)
-          .then(response => {
-            console.log(response)
-            return response.json()
-          })
+          .then(response => response.json())
           .catch(() => handleError(domainMsg('tags')))
       }
     }
@@ -80,7 +59,7 @@ export function fetchDomain () {
     let sourcesPromise = Promise.resolve([])
     if (process.env.features.USE_SOURCES) {
       if (!SOURCES_URL) {
-        sourcesPromise = Promise.resolve(makeError('USE_SOURCES is true, but you have not provided a SOURCES_URL'))
+        sourcesPromise = Promise.resolve(makeError('USE_SOURCES is true, but you have not provided a SOURCES_EXT'))
       } else {
         sourcesPromise = fetch(SOURCES_URL)
           .then(response => response.json())
@@ -151,9 +130,6 @@ export function fetchSource(source) {
           } else {
             return response.json()
           }
-        })
-        .then(sources => {
-          dispatch(_debugger(sources))
         })
         .catch(err => {
           dispatch(fetchSourceError(err.message))

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -98,7 +98,8 @@ class Dashboard extends React.Component {
         <Toolbar
           isNarrative={!!app.narrative}
           methods={{
-            onFilter: actions.updateTagFilters,
+            onTagFilter: actions.updateTagFilters,
+            onCategoryFilter: actions.updateCategoryFilters,
             onSelectNarrative: this.setNarrative
           }}
         />

--- a/src/components/SourceOverlay.jsx
+++ b/src/components/SourceOverlay.jsx
@@ -19,7 +19,7 @@ function SourceOverlay ({ source, onCancel }) {
       <Img
       className='source-image'
       src={path}
-      loader={<Spinner />}
+      loader={<div style={{ width: '400px', height: '400px' }}><Spinner /></div>}
       unloader={<NoSource failedUrls={source.paths} />}
       />
       </div>
@@ -107,8 +107,8 @@ function SourceOverlay ({ source, onCancel }) {
     return (
       <div>
         {img ? img : ''}
-        {vid ? `, ${vid}`: ''}
-        {txt ? `, ${txt}`: ''}
+        {(img && vid) ? `, ${vid}`: (vid || '')}
+        {((img || vid) && txt) ? `, ${txt}`: (txt || '')}
       </div>
     )
   }
@@ -145,6 +145,7 @@ function SourceOverlay ({ source, onCancel }) {
           <div className="mo-box">
             {title? <p><b>{title}</b></p> : null}
             <div>{_renderCounts(counts)}</div>
+            <hr />
             {type ? <h4>Media type</h4> : null}
             {type ? <p><i className="material-icons left">perm_media</i>{type}</p> : null}
             {date ? <h4>Date</h4> : null}

--- a/src/components/TagListPanel.jsx
+++ b/src/components/TagListPanel.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Checkbox from './presentational/Checkbox';
+import copy from '../js/data/copy.json';
 
 class TagListPanel extends React.Component {
 
@@ -20,9 +21,10 @@ class TagListPanel extends React.Component {
     this.computeTree(nextProps.tags);//.children[nextProps.tagType]);
   }
 
-  onClickCheckbox(tag) {
-    tag.active = !tag.active
-    this.props.onFilter(tag);
+  onClickCheckbox(obj, type) {
+    obj.active = !obj.active
+    if (type === 'category') this.props.onCategoryFilter(obj);
+    if (type === 'tag') this.props.onTagFilter(obj);
   }
 
   createNodeComponent (node, depth) {
@@ -35,7 +37,7 @@ class TagListPanel extends React.Component {
           <Checkbox
             label={node.key}
             isActive={node.active}
-            onClickCheckbox={() => this.onClickCheckbox(node)}
+            onClickCheckbox={() => this.onClickCheckbox(node, 'tag')}
           />
       </li>
     );
@@ -61,15 +63,42 @@ class TagListPanel extends React.Component {
   }
 
   renderTree() {
-    return this.state.treeComponents.map(c => c);
+    return (
+      <div>
+        <h2>{copy[this.props.language].toolbar.tags}</h2>
+        {this.state.treeComponents.map(c => c)}
+      </div>
+    )
+  }
+
+  renderCategoryTree() {
+    return (
+      <div>
+        <h2>{copy[this.props.language].toolbar.categories}</h2>
+        {this.props.categories.map(cat => {
+          return (<li
+            key={cat.category.replace(/ /g,"_")}
+            className={'tag-filter active'}
+            style={{ marginLeft: '20px' }}
+          >
+            <Checkbox
+              label={cat.category}
+              isActive={cat.active}
+              onClickCheckbox={() => this.onClickCheckbox(cat, 'category')}
+            />
+          </li>)
+          })
+        }
+      </div>
+    )
   }
 
   render() {
-
     return (
       <div className="react-innertabpanel">
-        <h2>Explore data by tag</h2>
-        <p>Explore freely all the data by selecting tags.</p>
+        <h2>{copy[this.props.language].toolbar.explore_by_tag__title}</h2>
+        <p>{copy[this.props.language].toolbar.explore_by_tag__description}</p>
+        {this.renderCategoryTree()}
         {this.renderTree()}
       </div>
     );

--- a/src/components/TagListPanel.jsx
+++ b/src/components/TagListPanel.jsx
@@ -22,7 +22,7 @@ class TagListPanel extends React.Component {
 
   onClickCheckbox(tag) {
     tag.active = !tag.active
-    this.props.filter(tag);
+    this.props.onFilter(tag);
   }
 
   createNodeComponent (node, depth) {

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -82,7 +82,8 @@ class Timeline extends React.Component {
   }
 
   makeScaleY(categories) {
-    const catsYpos = categories.map((g, i) => (i + 1) * this.state.dims.trackHeight / categories.length);
+    const tickHeight = 15;
+    const catsYpos = categories.map((g, i) => (i + 1) * this.state.dims.trackHeight / categories.length + tickHeight / 2);
     return d3.scaleOrdinal()
       .domain(categories)
       .range(catsYpos);

--- a/src/components/TimelineCategories.jsx
+++ b/src/components/TimelineCategories.jsx
@@ -25,7 +25,7 @@ class TimelineCategories extends React.Component {
   }
 
   getY(idx) {
-    return (idx + 1) * this.props.dims.trackHeight / this.props.categories.length
+    return (idx + 1) * this.props.dims.trackHeight / this.props.categories.length + 7.5;
   }
 
   renderCategory(category, idx) {

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -81,7 +81,7 @@ class Toolbar extends React.Component {
             categories={this.props.categories}
             tagFilters={this.props.tagFilters}
             categoryFilters={this.props.categoryFilters}
-            filter={this.props.filter}
+            onFilter={this.props.methods.onFilter}
             language={this.props.language}
           />
         </TabPanel>
@@ -90,13 +90,13 @@ class Toolbar extends React.Component {
     return '';
   }
 
-  renderToolbarTab(_selected, label) {
+  renderToolbarTab(_selected, label, icon_key) {
     const isActive = (this.state._selected === _selected);
     let classes = (isActive) ? 'toolbar-tab active' : 'toolbar-tab';
 
     return (
       <div className={classes} onClick={() => { this.selectTab(_selected); }}>
-        <i className="material-icons">timeline</i>
+        <i className="material-icons">{icon_key}</i>
         <div className="tab-caption">{label}</div>
       </div>
     );
@@ -104,7 +104,7 @@ class Toolbar extends React.Component {
 
   renderToolbarTabs() {
     const title = copy[this.props.language].toolbar.title;
-    const isTags = this.props.tags && (this.props.tags.children > 0);
+    const isTags = this.props.tags && (Object.keys(this.props.tags.children) > 0);
 
     return (
       <div className="toolbar">
@@ -125,7 +125,7 @@ class Toolbar extends React.Component {
         {this.renderClosePanel()}
         <Tabs selectedIndex={this.state._selected}>
           {this.renderToolbarNarrativePanel()}
-          {/* {this.renderToolbarTagPanel()} */}
+          {this.renderToolbarTagPanel()}}
         </Tabs>
       </div>
     )
@@ -150,15 +150,15 @@ class Toolbar extends React.Component {
 
   renderToolbarTabs() {
     const title = copy[this.props.language].toolbar.title;
-    const isTags = this.props.tags && (this.props.tags.children > 0);
+    const isTags = this.props.tags && this.props.tags.children;
 
     return (
       <div className="toolbar">
         <div className="toolbar-header"><p>{title}</p></div>
         <div className="toolbar-tabs">
           {/*this.renderToolbarTab(0, 'search')*/}
-          {this.renderToolbarTab(0, 'Narratives')}
-          {(isTags) ? this.renderToolbarTab(1, 'Explore by tag') : ''}
+          {this.renderToolbarTab(0, 'Narratives', 'timeline')}
+          {(isTags) ? this.renderToolbarTab(1, 'Explore by tag', 'style') : ''}
         </div>
         <ToolbarBottomActions
           sites={{

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -81,7 +81,8 @@ class Toolbar extends React.Component {
             categories={this.props.categories}
             tagFilters={this.props.tagFilters}
             categoryFilters={this.props.categoryFilters}
-            onFilter={this.props.methods.onFilter}
+            onTagFilter={this.props.methods.onTagFilter}
+            onCategoryFilter={this.props.methods.onCategoryFilter}
             language={this.props.language}
           />
         </TabPanel>
@@ -185,11 +186,11 @@ class Toolbar extends React.Component {
 function mapStateToProps(state) {
   return {
     tags: selectors.getTagTree(state),
-    categories: selectors.selectCategories(state),
+    categories: selectors.getCategories(state),
     narratives: selectors.selectNarratives(state),
     language: state.app.language,
     tagFilters: selectors.selectTagList(state),
-    categoryFilter: state.app.filters.categories,
+    categoryFilters: selectors.selectCategories(state),
     viewFilters: state.app.filters.views,
     features: state.app.features,
     narrative: state.app.narrative,

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -103,22 +103,6 @@ class Toolbar extends React.Component {
     );
   }
 
-  renderToolbarTabs() {
-    const title = copy[this.props.language].toolbar.title;
-    const isTags = this.props.tags && (Object.keys(this.props.tags.children) > 0);
-
-    return (
-      <div className="toolbar">
-        <div className="toolbar-header"><p>{title}</p></div>
-        <div className="toolbar-tabs">
-          {/*this.renderToolbarTab(0, 'search')*/}
-          {this.renderToolbarTab(0, 'Focus stories')}
-          {this.renderToolbarTab(1, 'Explore freely')}
-        </div>
-      </div>
-    )
-  }
-
   renderToolbarPanels() {
     let classes = (this.state._selected >= 0) ? 'toolbar-panels' : 'toolbar-panels folded';
     return (
@@ -151,6 +135,8 @@ class Toolbar extends React.Component {
 
   renderToolbarTabs() {
     const title = copy[this.props.language].toolbar.title;
+    const narratives_label = copy[this.props.language].toolbar.narratives_label;
+    const tags_label = copy[this.props.language].toolbar.tags_label;
     const isTags = this.props.tags && this.props.tags.children;
 
     return (
@@ -158,8 +144,8 @@ class Toolbar extends React.Component {
         <div className="toolbar-header"><p>{title}</p></div>
         <div className="toolbar-tabs">
           {/*this.renderToolbarTab(0, 'search')*/}
-          {this.renderToolbarTab(0, 'Narratives', 'timeline')}
-          {(isTags) ? this.renderToolbarTab(1, 'Explore by tag', 'style') : ''}
+          {this.renderToolbarTab(0, narratives_label, 'timeline')}
+          {(isTags) ? this.renderToolbarTab(1, tags_label, 'style') : ''}
         </div>
         <ToolbarBottomActions
           sites={{

--- a/src/js/data/copy.json
+++ b/src/js/data/copy.json
@@ -108,12 +108,14 @@
           "placeholder": "Search"
         }
       },
-      "narrative_panel_title": "Focus narratives",
+      "narratives_label": "Narratives",
       "narrative_summary": "Here you can follow some curated stories we have found in the data.",
       "categories": "Categories",
       "tags": "Tags",
+      "tags_label": "Tags",
       "explore_by_tag__title": "Explore by tag or category",
       "explore_by_tag__description": "Selecting tags or categories, you'll see only those events that are tagged accordingly. If you select nothing, as well as everything, all data will be displayed."
+
     },
     "timeline": {
       "zooms": [

--- a/src/js/data/copy.json
+++ b/src/js/data/copy.json
@@ -18,6 +18,10 @@
     },
     "toolbar": {
       "title": "TITLE",
+      "categories": "Categories",
+      "tags": "Tags",
+      "explore_by_tag__title": "Explore by tag or category",
+      "explore_by_tag__description": "Selecting tags or categories, you'll see only those events that are tagged accordingly. If you select nothing, as well as everything, all data will be displayed.",
       "panels": {
         "mentions": {
           "title": "Personas",
@@ -105,7 +109,11 @@
         }
       },
       "narrative_panel_title": "Focus narratives",
-      "narrative_summary": "Here you can follow some curated stories we have found in the data."
+      "narrative_summary": "Here you can follow some curated stories we have found in the data.",
+      "categories": "Categories",
+      "tags": "Tags",
+      "explore_by_tag__title": "Explore by tag or category",
+      "explore_by_tag__description": "Selecting tags or categories, you'll see only those events that are tagged accordingly. If you select nothing, as well as everything, all data will be displayed."
     },
     "timeline": {
       "zooms": [

--- a/src/js/utilities.js
+++ b/src/js/utilities.js
@@ -116,3 +116,11 @@ export function injectSource(id) {
     }
   })
 }
+
+export function urlFromEnv(ext) {
+  if (process.env[ext]) {
+    return `${process.env.SERVER_ROOT}${process.env[ext]}`
+  } else {
+    return null
+  }
+}

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -1,11 +1,10 @@
 import initial from '../store/initial.js'
 
-import { parseDate } from '../js/utilities.js'
-
 import {
   UPDATE_HIGHLIGHTED,
   UPDATE_SELECTED,
   UPDATE_TAGFILTERS,
+  UPDATE_CATEGORYFILTERS,
   UPDATE_TIMERANGE,
   UPDATE_NARRATIVE,
   INCREMENT_NARRATIVE_CURRENT,
@@ -136,6 +135,25 @@ function updateTagFilters(appState, action) {
   })
 }
 
+function updateCategoryFilters(appState, action) {
+  const categoryFilters = appState.filters.categories.slice(0)
+
+  const catFilter = categoryFilters.find(cF => cF.category === action.category.category);
+
+  if (!catFilter) {
+    categoryFilters.push(action.category)
+  } else {
+    catFilter.active = (!!action.category.active);
+  }
+  
+
+  return Object.assign({}, appState, {
+    filters: Object.assign({}, appState.filters, {
+      categories: categoryFilters
+    })
+  })
+}
+
 function updateTimeRange(appState, action) { // XXX
   return Object.assign({}, appState, {
     filters: Object.assign({}, appState.filters, {
@@ -254,6 +272,8 @@ function app(appState = initial.app, action) {
       return updateSelected(appState, action)
     case UPDATE_TAGFILTERS:
       return updateTagFilters(appState, action)
+    case UPDATE_CATEGORYFILTERS:
+      return updateCategoryFilters(appState, action)
     case UPDATE_TIMERANGE:
       return updateTimeRange(appState, action)
     case UPDATE_NARRATIVE:

--- a/src/reducers/schema/eventSchema.js
+++ b/src/reducers/schema/eventSchema.js
@@ -13,7 +13,7 @@ const eventSchema = Joi.object().keys({
     category:         Joi.string().required(),
     narratives:       Joi.array(),
     sources:          Joi.array(),
-    tags:             Joi.string().allow(''),
+    tags:             Joi.array().allow(''),
     comments:         Joi.string().allow(''),
     timestamp:        Joi.string().required(),
 

--- a/src/scss/mediaoverlay.scss
+++ b/src/scss/mediaoverlay.scss
@@ -2,7 +2,6 @@ $panel-width: 800px;
 $panel-height: 700px;
 $vimeo-width: $panel-width - 100;
 $vimeo-height: $panel-height / 2;
-
 $padding: 20px;
 $header-inset: 10px;
 
@@ -21,7 +20,6 @@ $header-inset: 10px;
 }
 
 .mo-container {
-  background-color: rgba(239, 239, 239, 0.9);
   // max-width: $panel-width;
   // min-width: $panel-width;
   // max-height: $panel-height;
@@ -29,7 +27,7 @@ $header-inset: 10px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  height: 80vh;
+  max-height: 80vh;
   max-width: 90vw;
   box-shadow: 0 19px 19px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.22);
 
@@ -37,8 +35,35 @@ $header-inset: 10px;
     flex: 1;
     display: flex;
     flex-direction: column;
+    align-items: center;
+  }
+}
+
+.mo-header {
+  min-height: 42px;
+  max-height: 42px;
+  margin-bottom: 2px;
+  border-radius: 2px;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  background-color: black;
+  color: white;
+
+  .mo-header-close {
+    display: flex;
     justify-content: center;
     align-items: center;
+    margin-left: $header-inset + 8px;
+  }
+
+  .mo-header-text {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    padding-right: $padding;
+    font-family: "Lato", Helvetica, sans-serif;
   }
 }
 
@@ -69,6 +94,7 @@ $header-inset: 10px;
 }
 
 .mo-media-container {
+  background-color: rgba(239, 239, 239, 0.9);
   box-sizing: border-box;
   min-width: 100%;
   max-height: 60vh;
@@ -93,6 +119,13 @@ $header-inset: 10px;
 }
 
 .mo-meta-container {
+  background-color: rgba(239, 239, 239, 0.9);
+  display: flex;
+  justify-content: center;  
+  box-sizing: border-box;
+  min-height: 100px;
+  min-width: $panel-width;
+  max-width: $panel-height;
   display: flex;
   justify-content: center;  
   box-sizing: border-box;
@@ -191,9 +224,8 @@ $header-inset: 10px;
 }
 
 .source-image-container, .source-text-container {
-  padding: 0 10em;
-  display: flex;
-  justify-content: center;
+  padding: $padding;
+  display: inline-block;
   align-items: center;
 }
 

--- a/src/scss/timeline.scss
+++ b/src/scss/timeline.scss
@@ -198,6 +198,10 @@
         stroke-dasharray: 1px 2px;
       }
 
+      .datetime {
+        /*transition: transform 0.2s ease;*/
+      }
+
       .event {
         cursor: pointer;
         opacity: .7;
@@ -212,6 +216,7 @@
         stroke: $offwhite;
         stroke-width: 2;
         stroke-dasharray: 5px 2px;
+        transition: transform 0.2s ease;
       }
 
       .coevent {

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -257,7 +257,6 @@ export const selectCategories = createSelector(
     categories.map(cat => {
       cat.active = (!cat.hasOwnProperty('active')) ? false : cat.active
     });
-    console.log(categories)
     return categories;
   }
 )

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -33,8 +33,7 @@ export const getTimeRange = state => state.app.filters.timerange
  */
 function isTaggedIn(event, tagFilters) {
   if (event.tags) {
-    const tagsInEvent = event.tags.split(",")
-    const isTagged = tagsInEvent.some((tag) => {
+    const isTagged = event.tags.some((tag) => {
       return tagFilters.find(tF => (tF.key === tag && tF.active))
     })
     return isTagged

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -145,11 +145,6 @@ export const selectNarratives = createSelector(
 
         steps.sort(compareTimestamp)
 
-        // steps.forEach((step, i) => {
-        //   narratives[key].byId[step.id].next = (i < steps.length - 2) ? steps[i + 1] : null
-        //   narratives[key].byId[step.id].prev = (i > 0) ? steps[i - 1] : null
-        // })
-
         if (narrativesMeta.find(n => n.id === key)) {
           narratives[key] = {
             ...narrativesMeta.find(n => n.id === key),
@@ -158,7 +153,9 @@ export const selectNarratives = createSelector(
         }
       })
 
-      return Object.values(narratives)
+      // Return narratives in original order
+      // + filter those that are undefined
+      return narrativesMeta.map(n => narratives[n.id]).filter(d => d);
 })
 
 /** Aggregate information about the narrative and the current step into


### PR DESCRIPTION
This PR implements the feature by which users can filter events by category. 

The categories are displayed in the same panel as tags, in a separate section.

Category and tag filters intersect. This means that if one category C is selected, only events belonging to C will be displayed. If additionally some tags (t1, t2) are then selected, only events belonging to C, tagged t1&t2 will then be displayed.

If no categories are selected, all events are in display.

closes #77