### PR TITLE
Markdown file container respects line breaks

### DIFF
--- a/src/scss/overlay.scss
+++ b/src/scss/overlay.scss
@@ -306,6 +306,7 @@ $overlay-bg: rgba(239,239,239,0.9);
   .md-container {
     width: 100%;
     overflow-wrap: break-word;
+    white-space: pre-line;
   }
 }
 


### PR DESCRIPTION
The line breaks in the linked markdown files are not currently respected. This might be one way to fix that. 