### PR TITLE
Fix to recognise line breaks

### DIFF
--- a/src/scss/card.scss
+++ b/src/scss/card.scss
@@ -203,6 +203,7 @@
     overflow: auto;
     margin-top: 0;
     border-bottom: none;
+    white-space: pre-line;
   }
 
   .tag {


### PR DESCRIPTION
The card summary also doesn't recognise line breaks but keeping this as a separate PR as it may have an impact on previous installs. 