### PR TITLE
correct mapbox tiles in example.config.js

### DIFF
--- a/example.config.js
+++ b/example.config.js
@@ -19,9 +19,7 @@ module.exports = {
       }
     },
     ui: {
-      style: {
-        // tiles: 'your-mapbox-account-name/x5678-map-id'
-      }
+      // tiles: 'your-mapbox-account-name/x5678-map-id'
     },
     features: {
       USE_CATEGORIES: false,


### PR DESCRIPTION
Fixes the bug referenced by @lostground [here](https://github.com/forensic-architecture/timemap/issues/106#issuecomment-672796800).