### PR TITLE
Render events in timeline when no categories exist

### DIFF
--- a/example.config.js
+++ b/example.config.js
@@ -21,13 +21,10 @@ module.exports = {
       // tiles: 'your-mapbox-account-name/x5678-map-id'
     },
     features: {
-      USE_CATEGORIES: true,
-      CATEGORIES_AS_FILTERS: true,
+      USE_CATEGORIES: false,
       USE_ASSOCIATIONS: true,
-      USE_SOURCES: true,
+      USE_SOURCES: false,
       USE_COVER: true,
-      USE_SITES: false,
-      USE_SHAPES: false,
       GRAPH_NONLOCATED: false,
       HIGHLIGHT_GROUPS: false
     }

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -1,4 +1,4 @@
-/* global L */
+/* global L, Event */
 import React from 'react'
 import { Portal } from 'react-portal'
 import Supercluster from 'supercluster'

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -45,6 +45,7 @@ class Map extends React.Component {
     if (this.map === null) {
       this.initializeMap()
     }
+    window.dispatchEvent(new Event('resize'))
   }
 
   componentWillReceiveProps (nextProps) {
@@ -75,8 +76,11 @@ class Map extends React.Component {
   }
 
   componentDidUpdate (prevState, prevProps) {
-    if (prevState.domain.locations.length > 0 && this.state.clusters.length === 0) {
-      this.loadClusterData(prevState.domain.locations)
+    // HACK: this is required because of something to do with Leaflet and the
+    // React lifecycle not playing nice... if you don't put this conditional,
+    // then the map sometimes appear blank on first load.
+    if (this.props.domain.locations.length > 0 && this.state.clusters.length === 0) {
+      this.loadClusterData(this.props.domain.locations)
     }
   }
 

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -268,14 +268,16 @@ class Timeline extends React.Component {
   }
 
   getY (event) {
+
     const { features, domain } = this.props
+    const { USE_CATEGORIES, GRAPH_NONLOCATED } = features
     const { categories } = domain
+    const categoriesExist = USE_CATEGORIES && categories && categories.length > 0
 
-    const categoriesExist = categories && categories.length > 0
 
-    const { GRAPH_NONLOCATED } = features
-
-    if (!categoriesExist) { return this.state.dims.trackHeight / 2 }
+    if (!categoriesExist) {
+      return this.state.dims.trackHeight / 2
+    }
 
     const { category, project } = event
 

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -268,12 +268,10 @@ class Timeline extends React.Component {
   }
 
   getY (event) {
-
     const { features, domain } = this.props
     const { USE_CATEGORIES, GRAPH_NONLOCATED } = features
     const { categories } = domain
     const categoriesExist = USE_CATEGORIES && categories && categories.length > 0
-
 
     if (!categoriesExist) {
       return this.state.dims.trackHeight / 2

--- a/src/components/presentational/Timeline/Events.js
+++ b/src/components/presentational/Timeline/Events.js
@@ -76,7 +76,7 @@ const TimelineEvents = ({
 }) => {
   const narIds = narrative ? narrative.steps.map(s => s.id) : []
 
-  function renderEvent (aggregated, event) {
+  function renderEvent (event) {
     if (narrative) {
       if (!(narIds.includes(event.id))) {
         return null
@@ -97,33 +97,38 @@ const TimelineEvents = ({
       }
     }
 
-    const relatedCategories = getEventCategories(event, categories)
+    // if an event has multiple categories, it should be rendered on each of
+    // those timelines
+    const ysAndStyles = getEventCategories(event, categories).map(cat => {
+      const eventY = getY({ ...event, category: cat.id })
 
-    if (relatedCategories && relatedCategories.length > 0) {
-      relatedCategories.forEach(cat => {
-        const eventY = getY({ ...event, category: cat.id })
+      let colour = event.colour ? event.colour : getCategoryColor(cat.id)
+      const styles = {
+        fill: colour,
+        fillOpacity: eventY > 0 ? calcOpacity(1) : 0,
+        transition: `transform ${transitionDuration / 1000}s ease`
+      }
 
-        let colour = event.colour ? event.colour : getCategoryColor(cat.id)
-        const styles = {
-          fill: colour,
-          fillOpacity: eventY > 0 ? calcOpacity(1) : 0,
-          transition: `transform ${transitionDuration / 1000}s ease`
-        }
+      return (eventY, styles)
+    })
 
-        aggregated.push(
-          renderShape(event, styles, {
-            x: getDatetimeX(event.datetime),
-            y: eventY,
-            eventRadius,
-            onSelect: () => onSelect(event),
-            dims,
-            highlights: features.HIGHLIGHT_GROUPS ? getHighlights(event.filters[features.HIGHLIGHT_GROUPS.filterIndexIndicatingGroup]) : [],
-            features
-          })
-        )
+    function getRender (y, styles) {
+      return renderShape(event, styles, {
+        x: getDatetimeX(event.datetime),
+        y,
+        eventRadius,
+        onSelect: () => onSelect(event),
+        dims,
+        highlights: features.HIGHLIGHT_GROUPS ? getHighlights(event.filters[features.HIGHLIGHT_GROUPS.filterIndexIndicatingGroup]) : [],
+        features
       })
     }
-    return aggregated
+
+    if (ysAndStyles.length === 0) {
+      return getRender(getY(event), { fill: getCategoryColor(null) })
+    } else {
+      return ysAndStyles.map(tup => getRender(tup[0], tup[1]))
+    }
   }
 
   let renderProjects = () => null
@@ -147,7 +152,7 @@ const TimelineEvents = ({
       clipPath={'url(#clip)'}
     >
       {renderProjects()}
-      {events.reduce(renderEvent, [])}
+      {events.map(renderEvent)}
     </g>
   )
 }


### PR DESCRIPTION
Fixes a cornercase bug that the categories refactor introduced, which is when an instance sets `USE_CATEGORIES` to false, or has no categories. A conditional statement in `renderEvent` in presentation/Timeline/Events.js was prohibiting anything from being rendered on the timeline, so I just added a default render of a single event when no categories exist.

I've also done a basic refactor and made it a bit clearer what's happening and why within that timeline render.