### PR TITLE
Fix/recursive corner case

### DIFF
--- a/src/common/utilities.js
+++ b/src/common/utilities.js
@@ -117,9 +117,29 @@ export function getImmediateFilterParent (associations, filter) {
 }
 
 /**
+ * Grab a meta filter's siblings, by way of the the `filter_path` hierarcy.
+*/
+export function getMetaFilterSiblings (allFilters, filterParent, filterKey) {
+  const idxParent = allFilters.map(f => {
+    return f.filter_paths.reduceRight((acc, path, idx) => {
+      if (path === filterParent) return f.filter_paths[idx + 1]
+      return acc
+    }, null)
+  })
+    .filter(metaFilter => !!metaFilter && metaFilter !== filterKey)
+  return [ ...(new Set(idxParent)) ]
+}
+
+/**
  * Grabs a given filter's siblings: the set of associations that share the same immediate filter parent.
 */
 export function getFilterSiblings (allFilters, filterParent, filterKey) {
+  const isMetaFilter = !allFilters.map(filt => filt.id).includes(filterKey)
+
+  if (isMetaFilter) {
+    return getMetaFilterSiblings(allFilters, filterParent, filterKey)
+  }
+
   return allFilters.reduce((acc, val) => {
     const valParent = getImmediateFilterParent(allFilters, val.id)
     if (valParent === filterParent && val.id !== filterKey) acc.push(val.id)

--- a/src/components/Toolbar/Layout.js
+++ b/src/components/Toolbar/Layout.js
@@ -63,6 +63,7 @@ class Toolbar extends React.Component {
         }
       }
     }
+
     this.props.methods.onSelectFilter(matchingKeys)
   }
 

--- a/src/components/Toolbar/Layout.js
+++ b/src/components/Toolbar/Layout.js
@@ -9,7 +9,7 @@ import FilterListPanel from './FilterListPanel'
 import CategoriesListPanel from './CategoriesListPanel'
 import BottomActions from './BottomActions'
 import copy from '../../common/data/copy.json'
-import { trimAndEllipse, getImmediateFilterParent, getFilterSiblings } from '../../common/utilities.js'
+import { trimAndEllipse, getImmediateFilterParent, getFilterSiblings, getFilterParents } from '../../common/utilities.js'
 
 class Toolbar extends React.Component {
   constructor (props) {
@@ -59,7 +59,8 @@ class Toolbar extends React.Component {
         }
 
         if (siblingsOff && isTurningOff) {
-          matchingKeys.push(parent)
+          const grandparentsOn = getFilterParents(filters, key).filter(filt => activeFilters.includes(filt))
+          matchingKeys = matchingKeys.concat(grandparentsOn)
         }
       }
     }

--- a/src/components/presentational/Checkbox.js
+++ b/src/components/presentational/Checkbox.js
@@ -8,8 +8,8 @@ export default ({ label, isActive, onClickCheckbox, backgroundColor }) => {
 
   return (
     <div className={(isActive) ? 'item active' : 'item'}>
-      <span onClick={() => onClickCheckbox()}>{label}</span>
-      <button onClick={() => onClickCheckbox()}>
+      <span>{label}</span>
+      <button onClick={onClickCheckbox}>
         <div className='checkbox' style={styles} />
       </button>
     </div>


### PR DESCRIPTION
This PR fixes two corner cases introduced by the coloring set algorithm that can cause the state of active filters and color to get way out of whack. (There is undefined and hard-to-interpret behavior whenever an incorrect action is dispatched for toggling filters, or for updating the coloring sets, as these two aspects of the state are tightly coupled.)

1. The `getFilterSiblings` function was always returning an empty array for meta filters (implicit filters that exist as parents in `filter_paths`, but not as associations in the sheet). This is because the function was only checking the `id`s of assocations, and not recursing/reducing up the `filter_path` array to find implicit filters. `getFilterSiblings` now delegates to `getMetaFilterSiblings` when the filter key passed is not an association, and returns the appropriate siblings. This was causing havoc in terms of appropriately toggling off grandparents when parent sets had been toggled off after toggling on a grandparent.

2. Similarly, the control flow that toggles off a paren when its last child is toggled off was not seeking further up the family tree, and appropriately toggling off grandparents as well if necessary. This also caused coloring havoc- now fixed.