### PR TITLE
Feature/handle cluster select from timeline

### DIFF
--- a/src/common/data/copy.json
+++ b/src/common/data/copy.json
@@ -126,10 +126,9 @@
       "filters": "Filters",
       "filters_label": "Filters",
       "explore_by_filter__title": "Explore by filter",
-      "explore_by_filter__description": "Selecting a filter will show you only those events that are annotated with the filter. If you select nothing, as well as everything, all data will be displayed.",
+      "explore_by_filter__description": "‘Filters’ refer to the types of incident. Select multiple filters to introduce colour-coding, up to a maximum of six filters. If no filters are selected, all datapoints are displayed.",
       "explore_by_category__title": "Explore events by category",
-      "explore_by_category__description": ""
-
+      "explore_by_category__description": "‘Categories’ refer to the victims of a given incident. If no categories are selected, all datapoints are displayed."
     },
     "timeline": {
       "zooms": [

--- a/src/common/utilities.js
+++ b/src/common/utilities.js
@@ -283,6 +283,15 @@ export function calcClusterSize (pointCount, totalPoints) {
   return Math.min(maxSize, 10 + (pointCount / totalPoints) * 150)
 }
 
+export function calculateTotalClusterPoints (clusters) {
+  return clusters.reduce((total, cl) => {
+    if (cl && cl.properties && cl.properties.cluster) {
+      total += cl.properties.point_count
+    }
+    return total
+  }, 0)
+}
+
 export function isLatitude (lat) {
   return !!lat && isFinite(lat) && Math.abs(lat) <= 90
 }

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -261,7 +261,7 @@ class Dashboard extends React.Component {
     }
 
     const popupStyles = {
-      fontSize: 24,
+      fontSize: 20,
       height: `calc(100vh - ${app.timeline.dimensions.height}px)`,
       width: '40vw',
       bottom: app.timeline.dimensions.height

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -183,6 +183,28 @@ class Map extends React.Component {
     return []
   }
 
+  getSelectedClusters () {
+    const { selected } = this.props.app
+    const selectedIds = selected.map(sl => sl.id)
+
+    if (this.state.clusters && this.state.clusters.length > 0) {
+      return this.state.clusters.reduce((acc, cl) => {
+        if (cl.properties.cluster) {
+          const children = this.getClusterChildren(cl.properties.cluster_id)
+          if (children && children.length > 0) {
+            children.forEach(child => {
+              if (selectedIds.includes(child.id)) {
+                acc.push(cl)
+              }
+            })
+          }
+        }
+        return acc
+      }, [])
+    }
+    return []
+  }
+
   alignLayers () {
     const mapNode = document.querySelector('.leaflet-map-pane')
     if (mapNode === null) return { transformX: 0, transformY: 0 }
@@ -336,11 +358,14 @@ class Map extends React.Component {
         coloringSet={this.props.app.coloringSet}
         getClusterChildren={this.getClusterChildren}
         filterColors={this.props.ui.filterColors}
+        selected={this.props.app.selected}
       />
     )
   }
 
   renderSelected () {
+    const selectedClusters = this.getSelectedClusters()
+    console.info(selectedClusters)
     return (
       <SelectedEvents
         svg={this.svgRef.current}

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -359,7 +359,6 @@ class Map extends React.Component {
         coloringSet={this.props.app.coloringSet}
         getClusterChildren={this.getClusterChildren}
         filterColors={this.props.ui.filterColors}
-        selected={this.props.app.selected}
       />
     )
   }

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -17,7 +17,7 @@ import Narratives from './presentational/Map/Narratives'
 import DefsMarkers from './presentational/Map/DefsMarkers.jsx'
 import LoadingOverlay from '../components/Overlay/Loading'
 
-import { mapClustersToLocations, isIdentical, isLatitude, isLongitude } from '../common/utilities'
+import { mapClustersToLocations, isIdentical, isLatitude, isLongitude, calculateTotalClusterPoints, calcClusterSize } from '../common/utilities'
 
 // NB: important constants for map, TODO: make statics
 const supportedMapboxMap = ['streets', 'satellite']
@@ -193,7 +193,8 @@ class Map extends React.Component {
           const children = this.getClusterChildren(cl.properties.cluster_id)
           if (children && children.length > 0) {
             children.forEach(child => {
-              if (selectedIds.includes(child.id)) {
+              const clusterPresent = acc.findIndex(item => item.id === cl.id) >= 0
+              if (selectedIds.includes(child.id) && !clusterPresent) {
                 acc.push(cl)
               }
             })
@@ -365,11 +366,34 @@ class Map extends React.Component {
 
   renderSelected () {
     const selectedClusters = this.getSelectedClusters()
-    console.info(selectedClusters)
+    const totalMarkers = []
+
+    this.props.app.selected.forEach(s => {
+      const { latitude, longitude } = s
+      totalMarkers.push({
+        latitude,
+        longitude,
+        radius: this.props.ui.eventRadius
+      })
+    })
+
+    const totalClusterPoints = calculateTotalClusterPoints(this.state.clusters)
+
+    selectedClusters.forEach(cl => {
+      if (cl.properties.cluster) {
+        const { coordinates } = cl.geometry
+        totalMarkers.push({
+          latitude: String(coordinates[1]),
+          longitude: String(coordinates[0]),
+          radius: calcClusterSize(cl.properties.point_count, totalClusterPoints)
+        })
+      }
+    })
+
     return (
       <SelectedEvents
         svg={this.svgRef.current}
-        selected={this.props.app.selected}
+        selected={totalMarkers}
         projectPoint={this.projectPoint}
         styles={this.props.ui.mapSelectedEvents}
       />

--- a/src/components/presentational/Map/Clusters.jsx
+++ b/src/components/presentational/Map/Clusters.jsx
@@ -19,7 +19,7 @@ const DefsClusters = () => (
   </defs>
 )
 
-function Cluster ({ cluster, size, projectPoint, totalPoints, styles, renderHover, onClick, getClusterChildren, coloringSet, filterColors }) {
+function Cluster ({ cluster, size, projectPoint, totalPoints, styles, renderHover, onClick, getClusterChildren, coloringSet, filterColors, selected }) {
   /**
   {
     geometry: {
@@ -34,6 +34,21 @@ function Cluster ({ cluster, size, projectPoint, totalPoints, styles, renderHove
     type: "Feature"
   }
   */
+  function renderBorder (size) {
+    return (
+      <React.Fragment>
+        {<circle
+          class='event-hover'
+          cx='0'
+          cy='0'
+          r={size}
+          stroke={colors.primaryHighlight}
+          fill-opacity='0.0'
+        />}
+      </React.Fragment>
+    )
+  }
+
   const { cluster_id: clusterId } = cluster.properties
 
   const individualChildren = getClusterChildren(clusterId)
@@ -74,7 +89,8 @@ function ClusterEvents ({
   isRadial,
   svg,
   clusters,
-  filterColors
+  filterColors,
+  selected
 }) {
   const totalPoints = clusters.reduce((total, cl) => {
     if (cl && cl.properties) {
@@ -117,6 +133,7 @@ function ClusterEvents ({
             cluster={c}
             filterColors={filterColors}
             size={clusterSize}
+            selected={selected}
             projectPoint={projectPoint}
             totalPoints={totalPoints}
             styles={{

--- a/src/components/presentational/Map/Clusters.jsx
+++ b/src/components/presentational/Map/Clusters.jsx
@@ -8,7 +8,8 @@ import {
   isLatitude,
   isLongitude,
   calculateColorPercentages,
-  zipColorsToPercentages } from '../../../common/utilities'
+  zipColorsToPercentages,
+  calculateTotalClusterPoints } from '../../../common/utilities'
 
 const DefsClusters = () => (
   <defs>
@@ -92,12 +93,7 @@ function ClusterEvents ({
   filterColors,
   selected
 }) {
-  const totalPoints = clusters.reduce((total, cl) => {
-    if (cl && cl.properties) {
-      total += cl.properties.point_count
-    }
-    return total
-  }, 0)
+  const totalPoints = calculateTotalClusterPoints(clusters)
 
   const styles = {
     fill: isRadial ? "url('#clusterGradient')" : colors.fallbackEventColor,

--- a/src/components/presentational/Map/Clusters.jsx
+++ b/src/components/presentational/Map/Clusters.jsx
@@ -20,7 +20,7 @@ const DefsClusters = () => (
   </defs>
 )
 
-function Cluster ({ cluster, size, projectPoint, totalPoints, styles, renderHover, onClick, getClusterChildren, coloringSet, filterColors, selected }) {
+function Cluster ({ cluster, size, projectPoint, totalPoints, styles, renderHover, onClick, getClusterChildren, coloringSet, filterColors }) {
   /**
   {
     geometry: {
@@ -35,21 +35,6 @@ function Cluster ({ cluster, size, projectPoint, totalPoints, styles, renderHove
     type: "Feature"
   }
   */
-  function renderBorder (size) {
-    return (
-      <React.Fragment>
-        {<circle
-          class='event-hover'
-          cx='0'
-          cy='0'
-          r={size}
-          stroke={colors.primaryHighlight}
-          fill-opacity='0.0'
-        />}
-      </React.Fragment>
-    )
-  }
-
   const { cluster_id: clusterId } = cluster.properties
 
   const individualChildren = getClusterChildren(clusterId)
@@ -129,7 +114,6 @@ function ClusterEvents ({
             cluster={c}
             filterColors={filterColors}
             size={clusterSize}
-            selected={selected}
             projectPoint={projectPoint}
             totalPoints={totalPoints}
             styles={{

--- a/src/components/presentational/Map/SelectedEvents.jsx
+++ b/src/components/presentational/Map/SelectedEvents.jsx
@@ -3,10 +3,10 @@ import { Portal } from 'react-portal'
 import colors from '../../../common/global.js'
 
 class MapSelectedEvents extends React.Component {
-  renderMarker (event) {
-    const { x, y } = this.props.projectPoint([event.latitude, event.longitude])
+  renderMarker (marker) {
+    const { x, y } = this.props.projectPoint([marker.latitude, marker.longitude])
     const styles = this.props.styles
-    const r = styles ? styles.r : 24
+    const r = marker.radius ? marker.radius + 5 : 24
     return (
       <g
         className='location-marker'

--- a/src/scss/cover.scss
+++ b/src/scss/cover.scss
@@ -145,8 +145,7 @@
 
   .hero {
     min-width: 100%;
-    max-width: 100%;
-    min-height: 150px;
+    min-height: 80px;
     margin: auto;
     display: flex;
     flex-direction: column;
@@ -216,6 +215,20 @@
     h1 { margin-bottom: -15px; margin-top: 30px; }
     h5 { margin-top: -15px; }
 
+
+    .md-container {
+      width: 100%;
+      overflow-wrap: break-word;
+      // white-space: pre-line;
+
+      ul {
+        list-style: none;
+      }
+  
+      li::before {
+        content: "* ";
+      }
+    }
 
     // mobile styles, remove overlay buttons
     @media only screen and (max-width: 1200px) {

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -173,6 +173,7 @@ export const selectLocations = createSelector(
         activeLocations[location] = {
           label: location,
           events: [event],
+          id: event.id,
           latitude: event.latitude,
           longitude: event.longitude
         }


### PR DESCRIPTION
This PR allows for clusters to be selected on the map when markers on the timeline are selected. A cluster is selected when the locations associated to the marker are a part of the cluster. The individual markers themselves are also rendered as selected because we want the user to be able to see the selected markers when they zoom in.

Higher level zoom:
![Screen Shot 2020-10-28 at 11 03 35 PM](https://user-images.githubusercontent.com/22159196/97531740-0c676180-1972-11eb-9e0d-9014037077fe.png)

Lower level zoom:
![Screen Shot 2020-10-28 at 11 06 59 PM](https://user-images.githubusercontent.com/22159196/97531850-505a6680-1972-11eb-9f9f-0e57844b162f.png)

