### PR TITLE
Modify filters logic to use association ID's and not titles

### DIFF
--- a/src/common/utilities.js
+++ b/src/common/utilities.js
@@ -344,7 +344,8 @@ export function calcClusterSize(pointCount, totalPoints) {
   /* The larger the cluster size, the higher the count of points that the cluster represents.
   Just like with opacity, we use a multiplication factor to ensure that clusters with higher point
   counts appear larger. */
-  const maxSize = totalPoints > 60 ? 40 : 20;
+  //TO-DO: Convert maxSize into a config var
+  const maxSize = totalPoints > 60 ? 60 : 40;
   return Math.min(maxSize, 10 + (pointCount / totalPoints) * 150);
 }
 

--- a/src/common/utilities.js
+++ b/src/common/utilities.js
@@ -345,8 +345,8 @@ export function calcClusterSize(pointCount, totalPoints) {
   Just like with opacity, we use a multiplication factor to ensure that clusters with higher point
   counts appear larger. */
   //TO-DO: Convert maxSize into a config var
-  const maxSize = totalPoints > 60 ? 60 : 40;
-  return Math.min(maxSize, 10 + (pointCount / totalPoints) * 150);
+  const maxSize = totalPoints > 60 ? 60 : 35;
+  return Math.min(maxSize, 10 + (pointCount / totalPoints) * 100);
 }
 
 export function calculateTotalClusterPoints(clusters) {

--- a/src/common/utilities.js
+++ b/src/common/utilities.js
@@ -7,6 +7,11 @@ if (!TIME_FMT) TIME_FMT = "HH:mm";
 
 export const language = process.env.store.app.language || "en-US";
 
+export function getPathLeaf(path) {
+  const splitPath = path.split("/");
+  return splitPath[splitPath.length - 1];
+}
+
 export function calcDatetime(date, time) {
   if (!time) time = "00:00";
   const dt = moment(`${date} ${time}`, `${DATE_FMT} ${TIME_FMT}`);

--- a/src/common/utilities.js
+++ b/src/common/utilities.js
@@ -194,16 +194,15 @@ export function removeFromColoringSet(coloringSet, filters) {
   return newColoringSets.filter((item) => item.length !== 0);
 }
 
-export function getEventCategories(event, categories) {
-  const matchedCategories = [];
-  if (event.associations && event.associations.length > 0) {
-    event.associations.reduce((acc, val) => {
-      const foundCategory = categories.find((cat) => cat.title === val);
-      if (foundCategory) acc.push(foundCategory);
-      return acc;
-    }, matchedCategories);
-  }
-  return matchedCategories;
+export function getEventCategories(event, activeCategories) {
+  const eventCats = event.associations.filter(
+    (a) => a.mode === ASSOCIATION_MODES.CATEGORY
+  );
+  return eventCats.reduce((acc, val) => {
+    const activeCatTitle = activeCategories.find((cat) => cat === val.title);
+    if (activeCatTitle) acc.push(activeCatTitle);
+    return acc;
+  }, []);
 }
 
 export function createFilterPathString(filter) {

--- a/src/common/utilities.js
+++ b/src/common/utilities.js
@@ -1,6 +1,8 @@
 import moment from "moment";
 import hash from "object-hash";
 
+import { ASSOCIATION_MODES } from "./constants";
+
 let { DATE_FMT, TIME_FMT } = process.env;
 if (!DATE_FMT) DATE_FMT = "MM/DD/YYYY";
 if (!TIME_FMT) TIME_FMT = "HH:mm";
@@ -204,6 +206,12 @@ export function getEventCategories(event, categories) {
   return matchedCategories;
 }
 
+export function createFilterPathString(filter) {
+  return filter.mode === ASSOCIATION_MODES.FILTER
+    ? filter.filter_paths.join("/")
+    : "";
+}
+
 /**
  * Inset the full source represenation from 'allSources' into an event. The
  * function is 'curried' to allow easy use with maps. To use for a single
@@ -394,7 +402,7 @@ export function calculateColorPercentages(set, coloringSet) {
 
     innerSet.forEach((val) => {
       val.associations.forEach((a) => {
-        const idx = associationMap[a];
+        const idx = associationMap[createFilterPathString(a)];
         if (!idx && idx !== 0) return;
         associationCounts[idx] += 1;
         totalAssociations += 1;

--- a/src/components/atoms/ColoredMarkers.js
+++ b/src/components/atoms/ColoredMarkers.js
@@ -39,7 +39,7 @@ function ColoredMarkers({ radius, colorPercentMap, styles, className }) {
 
         return (
           <path
-            class={className}
+            className={className}
             id={`arc_${idx}`}
             d={arc}
             style={extraStyles}

--- a/src/components/controls/FilterListPanel.js
+++ b/src/components/controls/FilterListPanel.js
@@ -2,7 +2,7 @@ import React from "react";
 import Checkbox from "../atoms/Checkbox";
 import marked from "marked";
 import copy from "../../common/data/copy.json";
-import { getFilterIdxFromColorSet } from "../../common/utilities";
+import { getFilterIdxFromColorSet, getPathLeaf } from "../../common/utilities";
 
 /** recursively get an array of node keys to toggle */
 function getFiltersToToggle(filter, activeFilters) {
@@ -26,8 +26,7 @@ function aggregatePaths(filters) {
     accumulatedPath
   ) {
     const childKey = Object.keys(children).find((path) => {
-      const splitPath = path.split("/");
-      const pathLeaf = splitPath[splitPath.length - 1];
+      const pathLeaf = getPathLeaf(path);
       return pathLeaf === headOfPath;
     });
     accumulatedPath.push(headOfPath);
@@ -57,6 +56,7 @@ function FilterListPanel({
 }) {
   function createNodeComponent(filter, depth) {
     const [key, children] = filter;
+    const pathLeaf = getPathLeaf(key);
     const matchingKeys = getFiltersToToggle(filter, activeFilters);
     const idxFromColorSet = getFilterIdxFromColorSet(key, coloringSet);
     const assignedColor =
@@ -71,12 +71,12 @@ function FilterListPanel({
 
     return (
       <li
-        key={key.replace(/ /g, "_")}
+        key={pathLeaf.replace(/ /g, "_")}
         className="filter-filter"
         style={{ ...styles }}
       >
         <Checkbox
-          label={key}
+          label={pathLeaf}
           isActive={activeFilters.includes(key)}
           onClickCheckbox={() => onSelectFilter(key, matchingKeys)}
           color={assignedColor}

--- a/src/components/controls/FilterListPanel.js
+++ b/src/components/controls/FilterListPanel.js
@@ -2,7 +2,11 @@ import React from "react";
 import Checkbox from "../atoms/Checkbox";
 import marked from "marked";
 import copy from "../../common/data/copy.json";
-import { getFilterIdxFromColorSet, getPathLeaf } from "../../common/utilities";
+import {
+  aggregateFilterPaths,
+  getFilterIdxFromColorSet,
+  getPathLeaf,
+} from "../../common/utilities";
 
 /** recursively get an array of node keys to toggle */
 function getFiltersToToggle(filter, activeFilters) {
@@ -17,33 +21,6 @@ function getFiltersToToggle(filter, activeFilters) {
 
   childKeys.push(key);
   return childKeys;
-}
-
-function aggregatePaths(filters) {
-  function insertPath(
-    children = {},
-    [headOfPath, ...remainder],
-    accumulatedPath
-  ) {
-    const childKey = Object.keys(children).find((path) => {
-      const pathLeaf = getPathLeaf(path);
-      return pathLeaf === headOfPath;
-    });
-    accumulatedPath.push(headOfPath);
-    const accumulatedPlusHead = accumulatedPath.join("/");
-    if (!childKey) children[accumulatedPlusHead] = {};
-    if (remainder.length > 0)
-      insertPath(children[accumulatedPlusHead], remainder, accumulatedPath);
-    return children;
-  }
-
-  const allPaths = [];
-  filters.forEach((filterItem) => allPaths.push(filterItem.filter_paths));
-  const aggregatedPaths = allPaths.reduce(
-    (children, path) => insertPath(children, path, []),
-    {}
-  );
-  return aggregatedPaths;
 }
 
 function FilterListPanel({
@@ -91,7 +68,7 @@ function FilterListPanel({
   }
 
   function renderTree(filters) {
-    const aggregatedFilterPaths = aggregatePaths(filters);
+    const aggregatedFilterPaths = aggregateFilterPaths(filters);
 
     return (
       <div>

--- a/src/components/space/carto/atoms/Clusters.js
+++ b/src/components/space/carto/atoms/Clusters.js
@@ -110,19 +110,19 @@ function ClusterEvents({
     return (
       <>
         <text
-          text-anchor="middle"
+          textAnchor="middle"
           y="3px"
           style={{ fontWeight: "bold", fill: "black", zIndex: 10000 }}
         >
           {txt}
         </text>
         <circle
-          class="event-hover"
+          className="event-hover"
           cx="0"
           cy="0"
           r={circleSize + 2}
           stroke={colors.primaryHighlight}
-          fill-opacity="0.0"
+          fillOpacity="0.0"
         />
       </>
     );

--- a/src/components/space/carto/atoms/Events.js
+++ b/src/components/space/carto/atoms/Events.js
@@ -35,12 +35,12 @@ function MapEvents({
     return (
       <>
         <circle
-          class="event-hover"
+          className="event-hover"
           cx="0"
           cy="0"
           r="10"
           stroke={colors.primaryHighlight}
-          fill-opacity="0.0"
+          fillOpacity="0.0"
         />
       </>
     );

--- a/src/components/time/Timeline.js
+++ b/src/components/time/Timeline.js
@@ -49,14 +49,13 @@ class Timeline extends React.Component {
     }
 
     if (
-      hash(nextProps.domain.categories) !==
-        hash(this.props.domain.categories) ||
+      hash(nextProps.activeCategories) !== hash(this.props.activeCategories) ||
       hash(nextProps.dimensions) !== hash(this.props.dimensions)
     ) {
       const { trackHeight, marginTop } = nextProps.dimensions;
       this.setState({
         scaleY: this.makeScaleY(
-          nextProps.domain.categories,
+          nextProps.activeCategories,
           trackHeight,
           marginTop
         ),
@@ -99,6 +98,7 @@ class Timeline extends React.Component {
         (cat) => !features.GRAPH_NONLOCATED.categories.includes(cat.title)
       );
     }
+
     const extraPadding = 0;
     const catHeight =
       categories.length > 2
@@ -107,10 +107,10 @@ class Timeline extends React.Component {
     const catsYpos = categories.map((g, i) => {
       return (i + 1) * catHeight + marginTop + extraPadding / 2;
     });
-    const catMap = categories.map((c) => c.title);
+    // const catMap = categories.map((c) => c.title);
 
     return (cat) => {
-      const idx = catMap.indexOf(cat);
+      const idx = categories.indexOf(cat);
       return catsYpos[idx];
     };
   }
@@ -302,13 +302,11 @@ class Timeline extends React.Component {
   }
 
   getY(event) {
-    const { features, domain } = this.props;
+    const { features, domain, activeCategories } = this.props;
     const { USE_CATEGORIES, GRAPH_NONLOCATED } = features;
-    // Categories represent active categories here
-    const { categories } = domain;
 
     const categoriesExist =
-      USE_CATEGORIES && categories && categories.length > 0;
+      USE_CATEGORIES && activeCategories && activeCategories.length > 0;
 
     if (!categoriesExist) {
       return this.state.dims.trackHeight / 2;
@@ -351,7 +349,8 @@ class Timeline extends React.Component {
     const heightStyle = { height: dims.height };
     const extraStyle = { ...heightStyle, ...foldedStyle };
     const contentHeight = { height: dims.contentHeight };
-    const { categories } = this.props.domain;
+    const { activeCategories: categories } = this.props;
+
     return (
       <div
         className={classes}
@@ -396,7 +395,7 @@ class Timeline extends React.Component {
                 onDragEnd={() => {
                   this.onDragEnd();
                 }}
-                categories={categories.map((c) => c.title)}
+                categories={categories}
                 features={this.props.features}
                 fallbackLabel={
                   copy[this.props.app.language].timeline
@@ -463,14 +462,10 @@ function mapStateToProps(state) {
   return {
     dimensions: selectors.selectDimensions(state),
     isNarrative: !!state.app.associations.narrative,
+    activeCategories: selectors.getActiveCategories(state),
     domain: {
       events: selectors.selectStackedEvents(state),
       projects: selectors.selectProjects(state),
-      categories: ((state) => {
-        const allcats = selectors.getCategories(state);
-        const active = selectors.getActiveCategories(state);
-        return allcats.filter((c) => active.includes(c.title));
-      })(state),
       narratives: state.domain.narratives,
     },
     app: {

--- a/src/components/time/Timeline.js
+++ b/src/components/time/Timeline.js
@@ -107,7 +107,6 @@ class Timeline extends React.Component {
     const catsYpos = categories.map((g, i) => {
       return (i + 1) * catHeight + marginTop + extraPadding / 2;
     });
-    // const catMap = categories.map((c) => c.title);
 
     return (cat) => {
       const idx = categories.indexOf(cat);

--- a/src/components/time/atoms/Events.js
+++ b/src/components/time/atoms/Events.js
@@ -134,7 +134,7 @@ const TimelineEvents = ({
     // those timelines: so we create as many event 'shadows' as there are
     // categories
     const evShadows = getEventCategories(event, categories).map((cat) => {
-      const y = getY({ ...event, category: cat.title });
+      const y = getY({ ...event, category: cat });
 
       const colour = event.colour ? event.colour : getCategoryColor(cat.title);
       const styles = {

--- a/src/components/time/atoms/Markers.js
+++ b/src/components/time/atoms/Markers.js
@@ -64,8 +64,9 @@ const TimelineMarkers = ({
     const isDot =
       (isLatitude(event.latitude) && isLongitude(event.longitude)) ||
       (features.GRAPH_NONLOCATED && event.projectOffset !== -1);
+
     const evShadows = getEventCategories(event, categories).map((cat) =>
-      getEventY({ ...event, category: cat.title })
+      getEventY({ ...event, category: cat })
     );
 
     function renderMarkerForEvent(y) {

--- a/src/reducers/validate/associationsSchema.js
+++ b/src/reducers/validate/associationsSchema.js
@@ -2,6 +2,7 @@ import Joi from "joi";
 
 const associationsSchema = Joi.object().keys({
   id: Joi.string().allow("").required(),
+  title: Joi.string().allow("").required(),
   desc: Joi.string().allow(""),
   mode: Joi.string().allow("").required(),
   filter_paths: Joi.array(),

--- a/src/reducers/validate/validators.js
+++ b/src/reducers/validate/validators.js
@@ -137,6 +137,14 @@ export function validateDomain(domain, features) {
   // append events with datetime and sort
   sanitizedDomain.events = sanitizedDomain.events.filter((event, idx) => {
     event.id = idx;
+    // event.associations comes in as a [association.ids...]; convert to actual association objects
+    event.associations = event.associations.reduce((acc, id) => {
+      const foundAssociation = sanitizedDomain.associations.find(
+        (elem) => elem.id === id
+      );
+      if (foundAssociation) acc.push(foundAssociation);
+      return acc;
+    }, []);
     // if lat, long come in with commas, replace with decimal format
     event.latitude = event.latitude.replace(",", ".");
     event.longitude = event.longitude.replace(",", ".");

--- a/src/reducers/validate/validators.js
+++ b/src/reducers/validate/validators.js
@@ -137,6 +137,10 @@ export function validateDomain(domain, features) {
   // append events with datetime and sort
   sanitizedDomain.events = sanitizedDomain.events.filter((event, idx) => {
     event.id = idx;
+    // if lat, long come in with commas, replace with decimal format
+    event.latitude = event.latitude.replace(",", ".");
+    event.longitude = event.longitude.replace(",", ".");
+
     event.datetime = calcDatetime(event.date, event.time);
     if (!isValidDate(event.datetime)) {
       discardedDomain.events.push({

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -5,6 +5,7 @@ import {
   dateMax,
   isLatitude,
   isLongitude,
+  createFilterPathString,
 } from "../common/utilities";
 import { isTimeRangedIn } from "./helpers";
 import { ASSOCIATION_MODES } from "../common/constants";
@@ -76,14 +77,18 @@ export const selectEvents = createSelector(
       const isMatchingFilter =
         (event.associations &&
           event.associations
-            .map((association) => activeFilters.includes(association))
+            .filter((a) => a.mode === ASSOCIATION_MODES.FILTER)
+            .map((association) =>
+              activeFilters.includes(createFilterPathString(association))
+            )
             .some((s) => s)) ||
         activeFilters.length === 0;
       const isActiveFilter = isMatchingFilter || activeFilters.length === 0;
       const isActiveCategory =
         (event.associations &&
           event.associations
-            .map((association) => activeCategories.includes(association))
+            .filter((a) => a.mode === ASSOCIATION_MODES.CATEGORY)
+            .map((association) => activeCategories.includes(association.title))
             .some((s) => s)) ||
         activeCategories.length === 0;
       let isActiveTime = isTimeRangedIn(event, timeRange);


### PR DESCRIPTION
Currently, filters are differentiated on two attributes: `title` and `filter_path`

When selecting a given filter from the tree, we look to filter events by the last element in the filters' path which is usually the title of the filter.

ex. **Type/Chemical/Tear Gas** is selected. This works so long as the last element in that path is unique.

In the following case, we have two filters with the same final element:

ex. **Parliamentary Motions/France**, **Export Bans/France** When attempting to select one of these, both are selected because we only look to filter on the last element.

This PR fixes the following by selecting filters by the uniqueness of their **full path**. Every event stores the full path instead of just the title of the association. Additionally, `event.associations` is now a list of `[association.ids]` which get interpolated at runtime to being a list of the full association objects. 