### PR TITLE
Feature/add additional shape types

### DIFF
--- a/src/components/time/atoms/DatetimePentagon.js
+++ b/src/components/time/atoms/DatetimePentagon.js
@@ -1,14 +1,6 @@
 import React from "react";
 
-const DatetimeStar = ({
-  x,
-  y,
-  r,
-  transform,
-  onSelect,
-  styleProps,
-  extraRender,
-}) => {
+const DatetimePentagon = ({ x, y, r, transform, onSelect, styleProps }) => {
   const s = (r * 2) / 3;
   return (
     <polygon
@@ -17,12 +9,12 @@ const DatetimeStar = ({
       x={x}
       y={y - r}
       style={styleProps}
-      points={`${x + s},${y - s} ${x - r},${y} ${x + r},${y} ${x - s},${
+      points={`${x},${y + s} ${x + s},${y} ${x + s},${y - s} ${x - s},${
         y - s
-      } ${x},${y + s}`}
+      } ${x - s},${y}`}
       transform={`rotate(180, ${x}, ${y})`}
     />
   );
 };
 
-export default DatetimeStar;
+export default DatetimePentagon;

--- a/src/components/time/atoms/DatetimeSquare.js
+++ b/src/components/time/atoms/DatetimeSquare.js
@@ -14,11 +14,11 @@ const DatetimeSquare = ({
       onClick={onSelect}
       className="event"
       x={x}
-      y={y - r}
+      y={y}
       style={styleProps}
       width={r}
       height={r}
-      transform={`rotate(45, ${x}, ${y})`}
+      transform={transform}
     />
   );
 };

--- a/src/components/time/atoms/DatetimeStar.js
+++ b/src/components/time/atoms/DatetimeStar.js
@@ -20,7 +20,7 @@ const DatetimeStar = ({
       points={`${x + s},${y - s} ${x - r},${y} ${x + r},${y} ${x - s},${
         y - s
       } ${x},${y + s}`}
-      transform={`rotate(180, ${x}, ${y})`}
+      transform={transform}
     />
   );
 };

--- a/src/components/time/atoms/DatetimeTriangle.js
+++ b/src/components/time/atoms/DatetimeTriangle.js
@@ -1,0 +1,18 @@
+import React from "react";
+
+const DatetimeTriangle = ({ x, y, r, transform, onSelect, styleProps }) => {
+  const s = (r * 2) / 3;
+  return (
+    <polygon
+      onClick={onSelect}
+      className="event"
+      x={x}
+      y={y - r}
+      style={styleProps}
+      points={`${x},${y + s} ${x + s},${y - s} ${x - s},${y - s}`}
+      transform={`rotate(180, ${x}, ${y})`}
+    />
+  );
+};
+
+export default DatetimeTriangle;

--- a/src/components/time/atoms/Events.js
+++ b/src/components/time/atoms/Events.js
@@ -68,7 +68,20 @@ function renderDiamond(event, styles, props) {
     <DatetimeSquare
       onSelect={props.onSelect}
       x={props.x}
-      y={props.y}
+      y={props.y - 1.8 * props.eventRadius}
+      r={1.8 * props.eventRadius}
+      styleProps={styles}
+      transform={`rotate(45, ${props.x}, ${props.y})`}
+    />
+  );
+}
+
+function renderSquare(event, styles, props) {
+  return (
+    <DatetimeSquare
+      onSelect={props.onSelect}
+      x={props.x}
+      y={props.y - (1.8 * props.eventRadius) / 2}
       r={1.8 * props.eventRadius}
       styleProps={styles}
     />
@@ -107,7 +120,7 @@ function renderStar(event, styles, props) {
       y={props.y}
       r={1.8 * props.eventRadius}
       styleProps={{ ...styles, fillRule: "nonzero" }}
-      transform="rotate(90)"
+      transform={`rotate(180, ${props.x}, ${props.y})`}
     />
   );
 }
@@ -155,6 +168,8 @@ const TimelineEvents = ({
         renderShape = renderTriangle;
       } else if (event.shape === "pentagon") {
         renderShape = renderPentagon;
+      } else if (event.shape === "square") {
+        renderShape = renderSquare;
       } else {
         renderShape = renderDot;
       }

--- a/src/components/time/atoms/Events.js
+++ b/src/components/time/atoms/Events.js
@@ -2,6 +2,8 @@ import React from "react";
 import DatetimeBar from "./DatetimeBar";
 import DatetimeSquare from "./DatetimeSquare";
 import DatetimeStar from "./DatetimeStar";
+import DatetimeTriangle from "./DatetimeTriangle";
+import DatetimePentagon from "./DatetimePentagon";
 import Project from "./Project";
 import ColoredMarkers from "../../atoms/ColoredMarkers";
 import {
@@ -73,6 +75,30 @@ function renderDiamond(event, styles, props) {
   );
 }
 
+function renderTriangle(event, styles, props) {
+  return (
+    <DatetimeTriangle
+      onSelect={props.onSelect}
+      x={props.x}
+      y={props.y}
+      r={1.5 * props.eventRadius}
+      styleProps={styles}
+    />
+  );
+}
+
+function renderPentagon(event, styles, props) {
+  return (
+    <DatetimePentagon
+      onSelect={props.onSelect}
+      x={props.x}
+      y={props.y}
+      r={1.5 * props.eventRadius}
+      styleProps={styles}
+    />
+  );
+}
+
 function renderStar(event, styles, props) {
   return (
     <DatetimeStar
@@ -125,6 +151,10 @@ const TimelineEvents = ({
         renderShape = renderDiamond;
       } else if (event.shape === "star") {
         renderShape = renderStar;
+      } else if (event.shape === "triangle") {
+        renderShape = renderTriangle;
+      } else if (event.shape === "pentagon") {
+        renderShape = renderPentagon;
       } else {
         renderShape = renderDot;
       }
@@ -137,6 +167,7 @@ const TimelineEvents = ({
       const y = getY({ ...event, category: cat });
 
       const colour = event.colour ? event.colour : getCategoryColor(cat.title);
+
       const styles = {
         fill: colour,
         fillOpacity: y > 0 ? calcOpacity(1) : 0,


### PR DESCRIPTION
This PR adds the following shape types available for use on the timeline as markers:

`Pentagon`
`Triangle`

It also modifies the `Star`, `Square`, and `Diamond` types to fit better on a timeline tick.