### PR TITLE
fixes #222 - npm install back to working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
-FROM mhart/alpine-node:16.4.2
-
+FROM mhart/alpine-node:10.11
 
 LABEL authors="Lachlan Kermode <lk@forensic-architecture.org>"
 
 # Install app dependencies
 COPY package.json /www/package.json
-RUN cd /www; npm install
+RUN cd /www; yarn
 
 # Copy app source
 COPY . /www
 WORKDIR /www
-RUN npm run build
+RUN yarn build
 
 # files available to copy at /www/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
-FROM mhart/alpine-node:10.11
+FROM mhart/alpine-node:16.4.2
+
 
 LABEL authors="Lachlan Kermode <lk@forensic-architecture.org>"
 
 # Install app dependencies
 COPY package.json /www/package.json
-RUN cd /www; yarn
+RUN cd /www; npm install
 
 # Copy app source
 COPY . /www
 WORKDIR /www
-RUN yarn build
+RUN npm run build
 
 # files available to copy at /www/build

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "reselect": "^3.0.1",
     "resolve": "1.18.1",
     "resolve-url-loader": "^3.1.2",
-    "sass-loader": "8.0.2",
+    "sass-loader": "10.2.1",
     "semver": "7.3.2",
     "style-loader": "1.3.0",
     "supercluster": "^7.1.0",
@@ -103,7 +103,7 @@
     "@babel/highlight": "^7.14.5",
     "ava": "1.0.0-beta.8",
     "mocha": "^5.2.0",
-    "node-sass": "4.13.1",
+    "node-sass": "^6.0",
     "redux-devtools": "^3.4.0"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "react-redux": "^5.0.4",
     "react-refresh": "^0.8.3",
     "react-tabs": "3.0.0",
-    "redux": "^3.6.0",
+    "redux": "^4.0.0",
     "redux-thunk": "^2.2.0",
     "reselect": "^3.0.1",
     "resolve": "1.18.1",


### PR DESCRIPTION
npm dependencies were broken and took some effort to fix, these changes should make the README instructions valid again, however the Dockerfile was not working before and is not working now, so that might also need some looking into.

it can also be beneficial to do some `npm audit fix` and even consider migrating to webpack 5 since some of the dependencies are getting deprecated and abandoned. 