### PR TITLE
Always render locations

### DIFF
--- a/src/components/space/carto/atoms/Events.js
+++ b/src/components/space/carto/atoms/Events.js
@@ -108,9 +108,7 @@ function MapEvents({
           transform={`translate(${x}, ${y})`}
           onClick={(e) => handleEventSelect(e, location)}
         >
-          {features.COLOR_BY_ASSOCIATION
-            ? renderLocationSlicesByAssociation(location)
-            : null}
+          {renderLocationSlicesByAssociation(location)}
           {extraRender ? extraRender() : null}
           {isSelected ? null : renderBorder()}
         </g>


### PR DESCRIPTION
I just attempted to run a config without any associations flags enabled, and noticed that there were no events rendered in the map (only clusters). This simple fix allows configs without associations. 