### PR TITLE
fix: adds binary-searched event to list

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -77,6 +77,11 @@ class Dashboard extends React.Component {
       // find in events
       const { events } = this.props.domain;
       const idx = this.findEventIdx(selected);
+      // binary search can return event with different id
+      if (events[idx].id !== selected.id) {
+        matchedEvents.push(events[idx]);
+      }
+      
       // check events before
       let ptr = idx - 1;
 


### PR DESCRIPTION
the result of the binary search could be an event with a different id, so me must make sure to display it too
Another alternative, less explicit, is to do `let ptr = idx;` in the check forward, but that might not be so perceptive when looking at the code for the 1st time. 

detected here: https://github.com/bellingcat/ukraine-timemap/issues/9