### PR TITLE
Use wikimedia as default OSM tile server

### DIFF
--- a/src/components/space/carto/Map.js
+++ b/src/components/space/carto/Map.js
@@ -109,7 +109,7 @@ class Map extends React.Component {
       !process.env.MAPBOX_TOKEN ||
       process.env.MAPBOX_TOKEN === defaultToken
     ) {
-      return "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png";
+      return "https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png";
     }
 
     if (supportedMapboxMap.indexOf(this.props.ui.tiles) !== -1) {


### PR DESCRIPTION
For reasons not entirely clear to me, the `https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png` OSM tile server now seems to return a 403 for localhost instances.

There is likely a fix related to sending the right user-agent, as [documented here](https://operations.osmfoundation.org/policies/tiles/); but switching to wikimedia is a cleaner fix for the time being. 