### PR TITLE
Feature/fix timeline shapes

### DIFF
--- a/src/common/utilities.js
+++ b/src/common/utilities.js
@@ -580,3 +580,5 @@ export function getFilterIdx(
 }
 
 export const isEmptyString = (s) => s.length === 0;
+
+export const isOdd = (num) => num % 2 !== 0;

--- a/src/components/time/atoms/DatetimeSquare.js
+++ b/src/components/time/atoms/DatetimeSquare.js
@@ -9,11 +9,12 @@ const DatetimeSquare = ({
   styleProps,
   extraRender,
 }) => {
+  const center = r / 2;
   return (
     <rect
       onClick={onSelect}
       className="event"
-      x={x}
+      x={x - center}
       y={y}
       style={styleProps}
       width={r}

--- a/src/components/time/atoms/DatetimeStar.js
+++ b/src/components/time/atoms/DatetimeStar.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { isOdd } from "../../../common/utilities";
 
 function createStar(numPoints, r, x, y) {
   const innerRadius = r;
@@ -7,7 +8,7 @@ function createStar(numPoints, r, x, y) {
   const points = [];
 
   for (let i = 0; i < numPoints * 2; i++) {
-    const radius = i & 1 ? innerRadius : outerRadius;
+    const radius = isOdd(i) ? innerRadius : outerRadius;
     points.push(radius * Math.sin(i * angle) + x);
     points.push(radius * Math.cos(i * angle) + y);
   }

--- a/src/components/time/atoms/DatetimeStar.js
+++ b/src/components/time/atoms/DatetimeStar.js
@@ -1,15 +1,21 @@
 import React from "react";
 
-const DatetimeStar = ({
-  x,
-  y,
-  r,
-  transform,
-  onSelect,
-  styleProps,
-  extraRender,
-}) => {
-  const s = (r * 2) / 3;
+function createStar(numPoints, r, x, y) {
+  const innerRadius = r;
+  const outerRadius = (r * 2) / numPoints;
+  const angle = Math.PI / numPoints;
+  const points = [];
+
+  for (let i = 0; i < numPoints * 2; i++) {
+    const radius = i & 1 ? innerRadius : outerRadius;
+    points.push(radius * Math.sin(i * angle) + x);
+    points.push(radius * Math.cos(i * angle) + y);
+  }
+
+  return points;
+}
+
+const DatetimeStar = ({ x, y, r, onSelect, styleProps, extraRender }) => {
   return (
     <polygon
       onClick={onSelect}
@@ -17,10 +23,7 @@ const DatetimeStar = ({
       x={x}
       y={y}
       style={styleProps}
-      points={`${x + s},${y - s} ${x - r},${y} ${x + r},${y} ${x - s},${
-        y - s
-      } ${x},${y + s}`}
-      transform={transform}
+      points={createStar(5, r, x, y)}
     />
   );
 };

--- a/src/components/time/atoms/Events.js
+++ b/src/components/time/atoms/Events.js
@@ -52,6 +52,7 @@ function renderBar(event, styles, props) {
 
   return (
     <DatetimeBar
+      key={event.id}
       onSelect={props.onSelect}
       category={event.category}
       events={[event]}
@@ -68,9 +69,10 @@ function renderBar(event, styles, props) {
 function renderDiamond(event, styles, props) {
   return (
     <DatetimeSquare
+      key={event.id}
       onSelect={props.onSelect}
       x={props.x}
-      y={props.y - 1.8 * props.eventRadius}
+      y={props.y - props.eventRadius}
       r={1.8 * props.eventRadius}
       styleProps={styles}
       transform={`rotate(45, ${props.x}, ${props.y})`}
@@ -81,6 +83,7 @@ function renderDiamond(event, styles, props) {
 function renderSquare(event, styles, props) {
   return (
     <DatetimeSquare
+      key={event.id}
       onSelect={props.onSelect}
       x={props.x}
       y={props.y - (1.8 * props.eventRadius) / 2}
@@ -93,6 +96,7 @@ function renderSquare(event, styles, props) {
 function renderTriangle(event, styles, props) {
   return (
     <DatetimeTriangle
+      key={event.id}
       onSelect={props.onSelect}
       x={props.x}
       y={props.y}
@@ -105,6 +109,7 @@ function renderTriangle(event, styles, props) {
 function renderPentagon(event, styles, props) {
   return (
     <DatetimePentagon
+      key={event.id}
       onSelect={props.onSelect}
       x={props.x}
       y={props.y}
@@ -117,12 +122,12 @@ function renderPentagon(event, styles, props) {
 function renderStar(event, styles, props) {
   return (
     <DatetimeStar
+      key={event.id}
       onSelect={props.onSelect}
       x={props.x}
       y={props.y}
-      r={1.8 * props.eventRadius}
+      r={1.5 * props.eventRadius}
       styleProps={{ ...styles, fillRule: "nonzero" }}
-      transform={`rotate(180, ${props.x}, ${props.y})`}
     />
   );
 }

--- a/src/components/time/atoms/Events.js
+++ b/src/components/time/atoms/Events.js
@@ -52,7 +52,6 @@ function renderBar(event, styles, props) {
 
   return (
     <DatetimeBar
-      key={event.id}
       onSelect={props.onSelect}
       category={event.category}
       events={[event]}
@@ -69,7 +68,6 @@ function renderBar(event, styles, props) {
 function renderDiamond(event, styles, props) {
   return (
     <DatetimeSquare
-      key={event.id}
       onSelect={props.onSelect}
       x={props.x}
       y={props.y - props.eventRadius}
@@ -83,7 +81,6 @@ function renderDiamond(event, styles, props) {
 function renderSquare(event, styles, props) {
   return (
     <DatetimeSquare
-      key={event.id}
       onSelect={props.onSelect}
       x={props.x}
       y={props.y - (1.8 * props.eventRadius) / 2}
@@ -96,7 +93,6 @@ function renderSquare(event, styles, props) {
 function renderTriangle(event, styles, props) {
   return (
     <DatetimeTriangle
-      key={event.id}
       onSelect={props.onSelect}
       x={props.x}
       y={props.y}
@@ -109,7 +105,6 @@ function renderTriangle(event, styles, props) {
 function renderPentagon(event, styles, props) {
   return (
     <DatetimePentagon
-      key={event.id}
       onSelect={props.onSelect}
       x={props.x}
       y={props.y}
@@ -122,7 +117,6 @@ function renderPentagon(event, styles, props) {
 function renderStar(event, styles, props) {
   return (
     <DatetimeStar
-      key={event.id}
       onSelect={props.onSelect}
       x={props.x}
       y={props.y}


### PR DESCRIPTION
- Removes React warning of unique keys for Timeline shapes.
- `SQUARE` and `DIAMOND` need to be centered in the x axis, otherwise they are not consistent with the other shapes. 
- The `STAR` shape looks weird to me:
![stars-deformed](https://user-images.githubusercontent.com/4657617/162092127-125e1202-8582-4645-ad63-e93e89cc3879.jpg)
With this PR it looks like this:
![stars-fixed](https://user-images.githubusercontent.com/4657617/162092161-fa8720d6-8bcb-4642-9fad-400c0e699941.jpg)

