### PR TITLE
fix: downgrade react-error-overlay to `6.0.9` to fix HMR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20618,9 +20618,9 @@
       }
     },
     "node_modules/react-error-overlay": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.10.tgz",
-      "integrity": "sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA=="
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
     },
     "node_modules/react-image": {
       "version": "1.5.1",
@@ -42175,9 +42175,9 @@
       }
     },
     "react-error-overlay": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.10.tgz",
-      "integrity": "sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA=="
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
     },
     "react-image": {
       "version": "1.5.1",


### PR DESCRIPTION
When working on the map, I noticed that hot module reloads are broken, resulting in the following error on each code change:

![image](https://user-images.githubusercontent.com/1682504/162483252-b1b23ea4-28c9-4694-b433-5b5d228e9487.png)

After that, the UI becomes unresponsive and I have to F5 the page.

I investigated it a bit and the root cause is a regression in a `react-dev-utils` component - see https://github.com/facebook/create-react-app/issues/11771 . Since we are using a lockfile, I downgraded to the previous patch version and HMR is working again.
