### PR TITLE
fix: correctly import `marked`

### DIFF
--- a/src/components/atoms/Md.js
+++ b/src/components/atoms/Md.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import marked from "marked";
+import { marked } from "marked";
 
 class Md extends React.Component {
   constructor(props) {

--- a/src/components/atoms/Media.js
+++ b/src/components/atoms/Media.js
@@ -1,5 +1,5 @@
 import React from "react";
-import marked from "marked";
+import { marked } from "marked";
 import Content from "./Content";
 import Controls from "./Controls";
 import { selectTypeFromPathWithPoster } from "../../common/utilities";

--- a/src/components/controls/CategoriesListPanel.js
+++ b/src/components/controls/CategoriesListPanel.js
@@ -1,5 +1,5 @@
 import React from "react";
-import marked from "marked";
+import { marked } from "marked";
 import PanelTree from "./atoms/PanelTree";
 import { ASSOCIATION_MODES } from "../../common/constants";
 

--- a/src/components/controls/FilterListPanel.js
+++ b/src/components/controls/FilterListPanel.js
@@ -1,6 +1,6 @@
 import React from "react";
 import Checkbox from "../atoms/Checkbox";
-import marked from "marked";
+import { marked } from "marked";
 import {
   aggregateFilterPaths,
   getFilterIdxFromColorSet,

--- a/src/components/controls/ShapesListPanel.js
+++ b/src/components/controls/ShapesListPanel.js
@@ -1,5 +1,5 @@
 import React from "react";
-import marked from "marked";
+import { marked } from "marked";
 import PanelTree from "./atoms/PanelTree";
 import { mapStyleByShape } from "../../common/utilities";
 import { SHAPE } from "../../common/constants";

--- a/src/components/controls/atoms/CustomField.js
+++ b/src/components/controls/atoms/CustomField.js
@@ -1,5 +1,5 @@
 import React from "react";
-import marked from "marked";
+import { marked } from "marked";
 
 // TODO could this be a security vulnerability?
 const CardCustomField = ({ title, value }) => (


### PR DESCRIPTION
recent update broke some marked imports.

![image](https://user-images.githubusercontent.com/1682504/162577617-4e5c07b8-d474-40fa-8c75-d3fcad3943c2.png)
